### PR TITLE
Correct number of slime buckets

### DIFF
--- a/src/main/java/tictac7x/daily/infoboxes/BucketsOfSlime.java
+++ b/src/main/java/tictac7x/daily/infoboxes/BucketsOfSlime.java
@@ -38,10 +38,10 @@ public class BucketsOfSlime extends DailyInfobox {
     private int getBucketsOfSlimeAmount() {
         int buckets_of_slime = 0;
 
-        final boolean easy   = plugin.isCompleted(Varbits.DIARY_VARROCK_EASY);
-        final boolean medium = plugin.isCompleted(Varbits.DIARY_VARROCK_MEDIUM);
-        final boolean hard   = plugin.isCompleted(Varbits.DIARY_VARROCK_HARD);
-        final boolean elite  = plugin.isCompleted(Varbits.DIARY_VARROCK_ELITE);
+        final boolean easy   = plugin.isCompleted(Varbits.DIARY_MORYTANIA_EASY);
+        final boolean medium = plugin.isCompleted(Varbits.DIARY_MORYTANIA_MEDIUM);
+        final boolean hard   = plugin.isCompleted(Varbits.DIARY_MORYTANIA_HARD);
+        final boolean elite  = plugin.isCompleted(Varbits.DIARY_MORYTANIA_ELITE);
 
         if (easy && medium && hard && elite) { buckets_of_slime = 39; } else
         if (easy && medium && hard) { buckets_of_slime = 26; } else


### PR DESCRIPTION
The daily number of slime buckets available was incorrectly based on which Varrock diaries were completed, rather than Morytania diaries. The images below show the before and after with Varrock completed up to the hard diaries, and Morytania completed up to elite.

Original plugin value:
![image](https://github.com/TicTac7x/runelite-plugins/assets/14106887/2e2440dc-a008-4b6a-b83c-5648b1956149)

New plugin value:
![image](https://github.com/TicTac7x/runelite-plugins/assets/14106887/939025b0-b2a3-4fd3-9468-d05823f03db9)