### PR TITLE
Changing timezone in Managing Miscellania to UTC

### DIFF
--- a/src/main/java/tictac7x/daily/dailies/KingdomOfMiscellania.java
+++ b/src/main/java/tictac7x/daily/dailies/KingdomOfMiscellania.java
@@ -22,7 +22,7 @@ public class KingdomOfMiscellania extends DailyInfobox {
     private final ConfigManager configManager;
 
     private final String percentageFormat = "%d%%";
-    private final ZoneId timezone = ZoneId.of("Europe/London");
+    private final ZoneId timezone = ZoneId.of("UTC");
     private final String tooltip = "You need to work harder to increase your kingdom of Miscellania favor: " + percentageFormat;
 
     private final int VARBIT_KINGDOM_APPROVAL = 72;


### PR DESCRIPTION
Europe/London is impacted by British Summer Time which results in the Miscellania infobox appearing one hour earlier than daily reset time. Changing the timezone to UTC should resolve this.