### PR TITLE
Add Scythe of Vitur

### DIFF
--- a/src/main/java/tictac7x/charges/TicTac7xChargesImprovedConfig.java
+++ b/src/main/java/tictac7x/charges/TicTac7xChargesImprovedConfig.java
@@ -99,6 +99,7 @@ public interface TicTac7xChargesImprovedConfig extends Config {
     String ring_of_the_elements = "ring_of_the_elements";
     String ring_of_endurance = "ring_of_endurance";
     String sanguinesti_staff = "sanguinesti_staff";
+    String scythe_of_vitur = "scythe_of_vitur";
     String seed_box = "seed_box";
     String skills_necklace = "skills_necklace";
     String skull_sceptre = "skull_sceptre";
@@ -925,6 +926,13 @@ public interface TicTac7xChargesImprovedConfig extends Config {
         ) default boolean sanguinestiStaffInfobox() { return true; }
 
         @ConfigItem(
+            keyName = scythe_of_vitur + infobox,
+            name = "Scythe of Vitur",
+            description = "",
+            section = infoboxes
+        ) default boolean scytheOfViturInfobox() { return true; }
+
+        @ConfigItem(
             keyName = skull_sceptre + infobox,
             name = "Skull sceptre",
             description = "",
@@ -1646,6 +1654,13 @@ public interface TicTac7xChargesImprovedConfig extends Config {
         ) default boolean sanguinestiStaffOverlay() { return true; }
 
         @ConfigItem(
+            keyName = scythe_of_vitur + overlay,
+            name = "Scythe of Vitur",
+            description = "",
+            section = overlays
+        ) default boolean scytheOfViturOverlay() { return true; }
+
+        @ConfigItem(
             keyName = skull_sceptre + overlay,
             name = "Skull sceptre",
             description = "",
@@ -1951,6 +1966,13 @@ public interface TicTac7xChargesImprovedConfig extends Config {
             description = sanguinesti_staff,
             section = debug
         ) default int getSanguinestiStaffCharges() { return Charges.UNKNOWN; }
+
+        @ConfigItem(
+            keyName = scythe_of_vitur,
+            name = scythe_of_vitur,
+            description = scythe_of_vitur,
+            section = debug
+        ) default int getScytheOfViturCharges() { return Charges.UNKNOWN; }
 
         @ConfigItem(
             keyName = skull_sceptre,

--- a/src/main/java/tictac7x/charges/TicTac7xChargesImprovedPlugin.java
+++ b/src/main/java/tictac7x/charges/TicTac7xChargesImprovedPlugin.java
@@ -205,6 +205,7 @@ public class TicTac7xChargesImprovedPlugin extends Plugin implements KeyListener
 			new W_IbansStaff(client, clientThread, configManager, itemManager, infoBoxManager, chatMessageManager, notifier, config, store, gson),
 			new W_PharaohsSceptre(client, clientThread, configManager, itemManager, infoBoxManager, chatMessageManager, notifier, config, store, gson),
 			new W_SanguinestiStaff(client, clientThread, configManager, itemManager, infoBoxManager, chatMessageManager, notifier, config, store, gson),
+			new W_ScytheOfVitur(client, clientThread, configManager, itemManager, infoBoxManager, chatMessageManager, notifier, config, store, gson),
 			new W_SkullSceptre(client, clientThread, configManager, itemManager, infoBoxManager, chatMessageManager, notifier, config, store, gson),
 			new W_SlayerStaffE(client, clientThread, configManager, itemManager, infoBoxManager, chatMessageManager, notifier, config, store, gson),
 			new W_TridentOfTheSeas(client, clientThread, configManager, itemManager, infoBoxManager, chatMessageManager, notifier, config, store, gson),

--- a/src/main/java/tictac7x/charges/item/listeners/ListenerOnHitsplatApplied.java
+++ b/src/main/java/tictac7x/charges/item/listeners/ListenerOnHitsplatApplied.java
@@ -28,7 +28,14 @@ public class ListenerOnHitsplatApplied extends ListenerBase {
                 triggerUsed = true;
             }
 
-            if (triggerUsed) return;
+            if (triggerUsed) {
+                // Once per game tick check.
+                if (trigger.oncePerGameTick.isPresent()) {
+                    trigger.triggerTick = client.getTickCount();
+                }
+
+                return;
+            }
         }
     }
 
@@ -67,6 +74,11 @@ public class ListenerOnHitsplatApplied extends ListenerBase {
 
         // Name check.
         if (trigger.hasTargetName.isPresent() && (event.getActor().getName() == null || !event.getActor().getName().equals(trigger.hasTargetName.get()))) {
+            return false;
+        }
+
+        // Once per game tick check.
+        if (trigger.oncePerGameTick.isPresent() && client.getTickCount() == trigger.triggerTick) {
             return false;
         }
 

--- a/src/main/java/tictac7x/charges/item/triggers/OnHitsplatApplied.java
+++ b/src/main/java/tictac7x/charges/item/triggers/OnHitsplatApplied.java
@@ -11,6 +11,8 @@ public class OnHitsplatApplied extends TriggerBase {
 
     public Optional<Boolean> moreThanZeroDamage = Optional.empty();
     public Optional<String> hasTargetName = Optional.empty();
+    public Optional<Boolean> oncePerGameTick = Optional.empty();
+    public int triggerTick = 0;
 
     public OnHitsplatApplied(final HitsplatTarget hitsplatTarget) {
         this.hitsplatTarget = hitsplatTarget;
@@ -23,6 +25,11 @@ public class OnHitsplatApplied extends TriggerBase {
 
     public OnHitsplatApplied hasTargetName(final String name) {
         this.hasTargetName = Optional.of(name);
+        return this;
+    }
+
+    public TriggerBase oncePerGameTick() {
+        this.oncePerGameTick = Optional.of(true);
         return this;
     }
 }

--- a/src/main/java/tictac7x/charges/items/W_CrystalHalberd.java
+++ b/src/main/java/tictac7x/charges/items/W_CrystalHalberd.java
@@ -64,7 +64,7 @@ public class W_CrystalHalberd extends ChargedItem {
         };
         this.triggers = new TriggerBase[]{
             new OnChatMessage("Your crystal halberd has (?<charges>.+) charges? remaining.").setDynamicallyCharges(),
-            new OnHitsplatApplied(ENEMY).isEquipped().decreaseCharges(1),
+            new OnHitsplatApplied(ENEMY).oncePerGameTick().isEquipped().decreaseCharges(1),
         };
     }
 }

--- a/src/main/java/tictac7x/charges/items/W_ScytheOfVitur.java
+++ b/src/main/java/tictac7x/charges/items/W_ScytheOfVitur.java
@@ -46,7 +46,7 @@ public class W_ScytheOfVitur extends ChargedItem {
 
         this.triggers = new TriggerBase[]{
             // Check.
-            new OnChatMessage("Your (Holy s|Sanguine s|S)cythe of vitur has (?<charges>.+) charges (remaining|left).").setDynamicallyCharges(),
+            new OnChatMessage("Your (Holy s|Sanguine s|[Ss])cythe (of vitur )?has (?<charges>.+) charges (remaining|left).").setDynamicallyCharges(),
 
             // Charge partially full.
             new OnChatMessage("You apply an additional .+ charges to your (Holy s|Sanguine s|S)cythe of vitur. It now has (?<charges>.+) charges in total.").setDynamicallyCharges(),
@@ -55,13 +55,7 @@ public class W_ScytheOfVitur extends ChargedItem {
             new OnChatMessage("You apply (?<charges>.+) charges to your (Holy s|Sanguine s|S)cythe of vitur.").setDynamicallyCharges(),
 
             // Attack.
-            // `OnHitsplatApplied` is triggered multiple times per attack, so we ensure that the charge is only decreased once per attack.
-            new OnHitsplatApplied(HitsplatTarget.ENEMY).moreThanZeroDamage().isEquipped().consumer(() -> {
-                final int tickCount = client.getTickCount();
-                if (tickCount == this.hitsplatTick) return;
-                decreaseCharges(1);
-                this.hitsplatTick = tickCount;
-            }),
+            new OnHitsplatApplied(HitsplatTarget.ENEMY).moreThanZeroDamage().oncePerGameTick().isEquipped().decreaseCharges(1),
         };
     }
 }

--- a/src/main/java/tictac7x/charges/items/W_ScytheOfVitur.java
+++ b/src/main/java/tictac7x/charges/items/W_ScytheOfVitur.java
@@ -1,0 +1,67 @@
+package tictac7x.charges.items;
+
+import com.google.gson.Gson;
+import net.runelite.api.Client;
+import net.runelite.api.ItemID;
+import net.runelite.client.Notifier;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+import tictac7x.charges.TicTac7xChargesImprovedConfig;
+import tictac7x.charges.item.ChargedItem;
+import tictac7x.charges.item.triggers.OnChatMessage;
+import tictac7x.charges.item.triggers.OnHitsplatApplied;
+import tictac7x.charges.item.triggers.TriggerBase;
+import tictac7x.charges.item.triggers.TriggerItem;
+import tictac7x.charges.store.HitsplatTarget;
+import tictac7x.charges.store.Store;
+
+public class W_ScytheOfVitur extends ChargedItem {
+    private int hitsplatTick;
+
+    public W_ScytheOfVitur(
+        final Client client,
+        final ClientThread clientThread,
+        final ConfigManager configManager,
+        final ItemManager itemManager,
+        final InfoBoxManager infoBoxManager,
+        final ChatMessageManager chatMessageManager,
+        final Notifier notifier,
+        final TicTac7xChargesImprovedConfig config,
+        final Store store,
+        final Gson gson
+    ) {
+        super(TicTac7xChargesImprovedConfig.scythe_of_vitur, ItemID.SCYTHE_OF_VITUR, client, clientThread, configManager, itemManager, infoBoxManager, chatMessageManager, notifier, config, store, gson);
+
+        this.items = new TriggerItem[]{
+            new TriggerItem(ItemID.SCYTHE_OF_VITUR),
+            new TriggerItem(ItemID.SCYTHE_OF_VITUR_UNCHARGED).fixedCharges(0),
+            new TriggerItem(ItemID.HOLY_SCYTHE_OF_VITUR),
+            new TriggerItem(ItemID.HOLY_SCYTHE_OF_VITUR_UNCHARGED).fixedCharges(0),
+            new TriggerItem(ItemID.SANGUINE_SCYTHE_OF_VITUR),
+            new TriggerItem(ItemID.SANGUINE_SCYTHE_OF_VITUR_UNCHARGED).fixedCharges(0),
+        };
+
+        this.triggers = new TriggerBase[]{
+            // Check.
+            new OnChatMessage("Your (Holy s|Sanguine s|S)cythe of vitur has (?<charges>.+) charges (remaining|left).").setDynamicallyCharges(),
+
+            // Charge partially full.
+            new OnChatMessage("You apply an additional .+ charges to your (Holy s|Sanguine s|S)cythe of vitur. It now has (?<charges>.+) charges in total.").setDynamicallyCharges(),
+
+            // Charge empty.
+            new OnChatMessage("You apply (?<charges>.+) charges to your (Holy s|Sanguine s|S)cythe of vitur.").setDynamicallyCharges(),
+
+            // Attack.
+            // `OnHitsplatApplied` is triggered multiple times per attack, so we ensure that the charge is only decreased once per attack.
+            new OnHitsplatApplied(HitsplatTarget.ENEMY).moreThanZeroDamage().isEquipped().consumer(() -> {
+                final int tickCount = client.getTickCount();
+                if (tickCount == this.hitsplatTick) return;
+                decreaseCharges(1);
+                this.hitsplatTick = tickCount;
+            }),
+        };
+    }
+}


### PR DESCRIPTION
Add Scythe of Vitur charges support. Due to the Scythe being capable of hitting 3 hitsplats in one tick but only consuming one charge *per attack*, I use the current game tick to ensure this only triggers once. If you have a better method for this then please let me know as I was stumped for a while!

Uncharged

![image](https://github.com/user-attachments/assets/44b6f9b9-6c1b-47f1-bdce-0ec6336e7c14)

Add 1 charge (100 minimum)

![image](https://github.com/user-attachments/assets/fb5949de-425a-4db5-b141-4805f17d2a7b)

Fixes #266
Fixes #280