### PR TITLE
Amulet of blood fury

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ If you find any dialogs or chat messages that don't seem to affect the charges o
 
 ### Jewellery
 
+- Alchemists Amulet
+- Amulet of Blood Fury
 - Binding necklace
 - Bracelet of clay
 - Bracelet of expeditious

--- a/src/main/java/tictac7x/charges/TicTac7xChargesImprovedConfig.java
+++ b/src/main/java/tictac7x/charges/TicTac7xChargesImprovedConfig.java
@@ -23,6 +23,7 @@ public interface TicTac7xChargesImprovedConfig extends Config {
     String storage = "_storage";
 
     String alchemists_amulet = "alchemists_amulet";
+    String amulet_of_blood_fury = "amulet_of_blood_fury";
     String arclight = "arclight";
     String ardougne_cloak = "ardougne_cloak";
     String ash_sanctifier = "ash_sanctifier";
@@ -995,6 +996,13 @@ public interface TicTac7xChargesImprovedConfig extends Config {
                 section = infoboxes
         ) default boolean alchemistsAmuletInfobox() { return true; }
 
+        @ConfigItem(
+                keyName = amulet_of_blood_fury + infobox,
+                name = "Amulet of Blood Fury",
+                description = "",
+                section = infoboxes
+        ) default boolean amuletOfBloodFuryInfobox() { return true; }
+
     @ConfigSection(
         name = "Overlays",
         description = "Choose for which charged items number is shown next to it",
@@ -1729,6 +1737,13 @@ public interface TicTac7xChargesImprovedConfig extends Config {
                 description = "",
                 section = overlays
         ) default boolean alchemistsAmuletOverlay() { return true; }
+
+        @ConfigItem(
+                keyName = amulet_of_blood_fury + overlay,
+                name = "Amulet of Blood Fury",
+                description = "",
+                section = overlays
+        ) default boolean amuletOfBloodFuryOverlay() { return true; }
 
     @ConfigSection(
         name = "Debug",

--- a/src/main/java/tictac7x/charges/TicTac7xChargesImprovedPlugin.java
+++ b/src/main/java/tictac7x/charges/TicTac7xChargesImprovedPlugin.java
@@ -243,6 +243,7 @@ public class TicTac7xChargesImprovedPlugin extends Plugin implements KeyListener
 
 			// Jewellery
 			new J_AlchemistsAmulet(client, clientThread, configManager, itemManager, infoBoxManager, chatMessageManager, notifier, config, store, gson),
+			new J_AmuletOfBloodFury(client, clientThread, configManager, itemManager, infoBoxManager, chatMessageManager, notifier, config, store, gson),
 			new J_BindingNecklace(client, clientThread, configManager, itemManager, infoBoxManager, chatMessageManager, notifier, config, store, gson),
 			new J_BraceletOfClay(client, clientThread, configManager, itemManager, infoBoxManager, chatMessageManager, notifier, config, store, gson),
 			new J_BraceletOfExpeditious(client, clientThread, configManager, itemManager, infoBoxManager, chatMessageManager, notifier, config, store, gson),

--- a/src/main/java/tictac7x/charges/item/listeners/ListenerOnHitsplatApplied.java
+++ b/src/main/java/tictac7x/charges/item/listeners/ListenerOnHitsplatApplied.java
@@ -10,12 +10,17 @@ import tictac7x.charges.TicTac7xChargesImprovedConfig;
 import tictac7x.charges.item.ChargedItemBase;
 import tictac7x.charges.item.triggers.OnHitsplatApplied;
 import tictac7x.charges.item.triggers.TriggerBase;
+import tictac7x.charges.store.WeaponAttackStyle;
 import tictac7x.charges.store.HitsplatGroup;
 import tictac7x.charges.store.HitsplatTarget;
 
 public class ListenerOnHitsplatApplied extends ListenerBase {
+    private final WeaponAttackStyle weaponAttackStyle;
+
     public ListenerOnHitsplatApplied(final Client client, final ItemManager itemManager, final ChargedItemBase chargedItem, final Notifier notifier, final TicTac7xChargesImprovedConfig config) {
         super(client, itemManager, chargedItem, notifier, config);
+
+        this.weaponAttackStyle = new WeaponAttackStyle(client);
     }
 
     public void trigger(final HitsplatApplied event) {
@@ -79,6 +84,11 @@ public class ListenerOnHitsplatApplied extends ListenerBase {
 
         // Once per game tick check.
         if (trigger.oncePerGameTick.isPresent() && client.getTickCount() == trigger.triggerTick) {
+            return false;
+        }
+
+        // Attack style check.
+        if (trigger.combatStyle.isPresent() && weaponAttackStyle.getCombatStyle() != trigger.combatStyle.get()) {
             return false;
         }
 

--- a/src/main/java/tictac7x/charges/item/triggers/OnHitsplatApplied.java
+++ b/src/main/java/tictac7x/charges/item/triggers/OnHitsplatApplied.java
@@ -1,5 +1,6 @@
 package tictac7x.charges.item.triggers;
 
+import tictac7x.charges.store.CombatStyle;
 import tictac7x.charges.store.HitsplatGroup;
 import tictac7x.charges.store.HitsplatTarget;
 
@@ -12,6 +13,7 @@ public class OnHitsplatApplied extends TriggerBase {
     public Optional<Boolean> moreThanZeroDamage = Optional.empty();
     public Optional<String> hasTargetName = Optional.empty();
     public Optional<Boolean> oncePerGameTick = Optional.empty();
+    public Optional<CombatStyle> combatStyle = Optional.empty();
     public int triggerTick = 0;
 
     public OnHitsplatApplied(final HitsplatTarget hitsplatTarget) {
@@ -30,6 +32,11 @@ public class OnHitsplatApplied extends TriggerBase {
 
     public TriggerBase oncePerGameTick() {
         this.oncePerGameTick = Optional.of(true);
+        return this;
+    }
+
+    public TriggerBase combatStyle(final CombatStyle combatStyle) {
+        this.combatStyle = Optional.of(combatStyle);
         return this;
     }
 }

--- a/src/main/java/tictac7x/charges/items/J_AmuletOfBloodFury.java
+++ b/src/main/java/tictac7x/charges/items/J_AmuletOfBloodFury.java
@@ -12,8 +12,11 @@ import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 import tictac7x.charges.TicTac7xChargesImprovedConfig;
 import tictac7x.charges.item.ChargedItem;
 import tictac7x.charges.item.triggers.OnChatMessage;
+import tictac7x.charges.item.triggers.OnHitsplatApplied;
 import tictac7x.charges.item.triggers.TriggerBase;
 import tictac7x.charges.item.triggers.TriggerItem;
+import tictac7x.charges.store.CombatStyle;
+import tictac7x.charges.store.HitsplatTarget;
 import tictac7x.charges.store.Store;
 
 public class J_AmuletOfBloodFury extends ChargedItem {
@@ -40,10 +43,13 @@ public class J_AmuletOfBloodFury extends ChargedItem {
             new OnChatMessage("You have successfully created an Amulet of blood fury.").setFixedCharges(10000),
 
             // Check.
-            new OnChatMessage("Your Amulet of blood fury (will work|can perform) for (?<charges>.+) more hits.").setDynamicallyCharges(),
+            new OnChatMessage("Your Amulet of blood fury (will work|can perform) for (?<charges>.+) more hits?.").setDynamicallyCharges(),
 
             // Charge.
-            new OnChatMessage("You have successfully added .+ hits to your Amulet of blood fury. It will now work for (?<charges>.+) more hits.").setDynamicallyCharges(),
+            new OnChatMessage("You have successfully added .+ hits? to your Amulet of blood fury. It will now work for (?<charges>.+) more hits?.").setDynamicallyCharges(),
+
+            // Take damage.
+            new OnHitsplatApplied(HitsplatTarget.ENEMY).combatStyle(CombatStyle.MELEE).isEquipped().decreaseCharges(1),
         };
     }
 }

--- a/src/main/java/tictac7x/charges/items/J_AmuletOfBloodFury.java
+++ b/src/main/java/tictac7x/charges/items/J_AmuletOfBloodFury.java
@@ -1,0 +1,49 @@
+package tictac7x.charges.items;
+
+import com.google.gson.Gson;
+import net.runelite.api.Client;
+import net.runelite.api.ItemID;
+import net.runelite.client.Notifier;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+import tictac7x.charges.TicTac7xChargesImprovedConfig;
+import tictac7x.charges.item.ChargedItem;
+import tictac7x.charges.item.triggers.OnChatMessage;
+import tictac7x.charges.item.triggers.TriggerBase;
+import tictac7x.charges.item.triggers.TriggerItem;
+import tictac7x.charges.store.Store;
+
+public class J_AmuletOfBloodFury extends ChargedItem {
+    public J_AmuletOfBloodFury(
+        final Client client,
+        final ClientThread clientThread,
+        final ConfigManager configManager,
+        final ItemManager itemManager,
+        final InfoBoxManager infoBoxManager,
+        final ChatMessageManager chatMessageManager,
+        final Notifier notifier,
+        final TicTac7xChargesImprovedConfig config,
+        final Store store,
+        final Gson gson
+    ) {
+        super(TicTac7xChargesImprovedConfig.amulet_of_blood_fury, ItemID.AMULET_OF_BLOOD_FURY, client, clientThread, configManager, itemManager, infoBoxManager, chatMessageManager, notifier, config, store, gson);
+
+        this.items = new TriggerItem[]{
+            new TriggerItem(ItemID.AMULET_OF_BLOOD_FURY),
+        };
+
+        this.triggers = new TriggerBase[]{
+            // Creation
+            new OnChatMessage("You have successfully created an Amulet of blood fury.").setFixedCharges(10000),
+
+            // Check.
+            new OnChatMessage("Your Amulet of blood fury (will work|can perform) for (?<charges>.+) more hits.").setDynamicallyCharges(),
+
+            // Charge.
+            new OnChatMessage("You have successfully added .+ hits to your Amulet of blood fury. It will now work for (?<charges>.+) more hits.").setDynamicallyCharges(),
+        };
+    }
+}

--- a/src/main/java/tictac7x/charges/store/CombatStyle.java
+++ b/src/main/java/tictac7x/charges/store/CombatStyle.java
@@ -1,0 +1,8 @@
+package tictac7x.charges.store;
+
+public enum CombatStyle {
+    MELEE,
+    RANGED,
+    MAGIC,
+    UNKNOWN,
+}

--- a/src/main/java/tictac7x/charges/store/WeaponAttackStyle.java
+++ b/src/main/java/tictac7x/charges/store/WeaponAttackStyle.java
@@ -1,0 +1,95 @@
+package tictac7x.charges.store;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.EnumID;
+import net.runelite.api.ParamID;
+import net.runelite.api.StructComposition;
+import net.runelite.api.VarPlayer;
+import net.runelite.api.Varbits;
+
+/**
+ * Get a generalised weapon style (melee/magic/ranged) from the current attack style.
+ *
+ * @see net.runelite.client.plugins.attackstyles.AttackStylesPlugin
+ */
+@Slf4j
+public class WeaponAttackStyle {
+    private final Client client;
+    private int[] weaponStyleStructs;
+
+    public WeaponAttackStyle(Client client) {
+        this.client = client;
+    }
+
+    public CombatStyle getCombatStyle() {
+        final int currentAttackStyleVarbit = client.getVarpValue(VarPlayer.ATTACK_STYLE);
+        final int currentEquippedWeaponTypeVarbit = client.getVarbitValue(Varbits.EQUIPPED_WEAPON_TYPE);
+        int weaponStyleEnum = client.getEnum(EnumID.WEAPON_STYLES).getIntValue(currentEquippedWeaponTypeVarbit);
+
+        weaponStyleStructs = client.getEnum(weaponStyleEnum).getIntVals();
+
+        AttackStyle attackStyle = getAttackStyle(currentAttackStyleVarbit);
+        CombatStyle selectedWeaponStyle = getWeaponFromAttackStyle(attackStyle);
+
+        log.debug("Weapon style: {}", selectedWeaponStyle);
+
+        return selectedWeaponStyle;
+    }
+
+    private AttackStyle getAttackStyle(int attackStyleVarbit) {
+        // Get selected weapon attack style
+        StructComposition attackStyleStruct = client.getStructComposition(weaponStyleStructs[attackStyleVarbit]);
+        String attackStyleName = attackStyleStruct.getStringValue(ParamID.ATTACK_STYLE_NAME);
+
+        // Get selected attack style
+        return AttackStyle.valueOf(attackStyleName.toUpperCase());
+    }
+
+    private CombatStyle getWeaponFromAttackStyle(AttackStyle attackStyle) {
+        switch (attackStyle) {
+            case ACCURATE:
+            case AGGRESSIVE:
+            case CONTROLLED:
+                return CombatStyle.MELEE;
+            case RANGING:
+            case LONGRANGE:
+                return CombatStyle.RANGED;
+            case CASTING:
+            case DEFENSIVE_CASTING:
+                return CombatStyle.MAGIC;
+            // "Defensive" is shared between melee and magic
+            // We can look at the first attack style to determine which one is in use
+            case DEFENSIVE:
+                AttackStyle firstAttackStyle = getAttackStyle(0);
+                log.debug("Defensive, maybe melee or magic: {}", firstAttackStyle);
+
+                return firstAttackStyle != AttackStyle.DEFENSIVE
+                    ? getWeaponFromAttackStyle(firstAttackStyle)
+                    : CombatStyle.UNKNOWN;
+            default:
+                return CombatStyle.UNKNOWN;
+        }
+    }
+
+    @Getter
+    enum AttackStyle {
+        ACCURATE("Accurate"),
+        AGGRESSIVE("Aggressive"),
+        DEFENSIVE("Defensive"),
+        CONTROLLED("Controlled"),
+        RANGING("Ranging"),
+        LONGRANGE("Longrange"),
+        CASTING("Casting"),
+        DEFENSIVE_CASTING("Defensive Casting"),
+        OTHER("Other");
+
+        private final String name;
+
+        AttackStyle(String name)
+        {
+            this.name = name;
+        }
+    }
+}


### PR DESCRIPTION
I'm looking to add Amulet of Blood Fury support, but I'm not 100% sure about the implementation, particularly around the attack style portion, so I'm submitting this as a draft now to get your feedback.

I added `WeaponAttackStyle` which decides if the weapon is melee/magic/ranged based on the selected attack style (pulled from RL AttackStylesPlugin)

Here are some additional reference pictures that are missing in #236. I pulled the creation message from a random YouTube video I found :joy: 

![2025-02-22_16-31](https://github.com/user-attachments/assets/30f3f3cf-8f04-4b1c-a71f-febf500f3b79)
![2025-02-22_15-08_1](https://github.com/user-attachments/assets/88cdd5f0-c5a1-4e59-ae9b-c28bd9906850)
![2025-02-22_15-08](https://github.com/user-attachments/assets/3b769858-d8e5-486d-8107-613e3ad991c3)

**Todo**

- [x] Scythe, if ANY hitsplat is >0, a charge is deducted per hitsplat. So a `0, 19` hit on a 2x2 NPC would deduct two charges. **needs more testing**
- [x] Powered staff longrange is "Defensive", shared with melee.
- [x] Potential loop when looking at the first style
- [x] Check thrown weapons like chins return ranged

Fixes #236 