### PR TITLE
Added Plank Make Spell Functionality for Plank Sack

### DIFF
--- a/src/main/java/tictac7x/charges/items/U_PlankSack.java
+++ b/src/main/java/tictac7x/charges/items/U_PlankSack.java
@@ -91,6 +91,28 @@ public class U_PlankSack extends ChargedItemWithStorage {
                 39527, 39528
             ),
 
+            // Plank Make on Log in Inventory
+            new OnXpDrop(Skill.MAGIC).onMenuOption("Cast").onMenuTarget(
+                    "Plank Make -> Logs").requiredItem(ItemID.PLANK_SACK).consumer(
+                    () -> {
+                        storage.add(ItemID.PLANK, 1);
+                    }),
+            new OnXpDrop(Skill.MAGIC).onMenuOption("Cast").onMenuTarget(
+                    "Plank Make -> Oak logs").requiredItem(ItemID.PLANK_SACK).consumer(
+                    () -> {
+                        storage.add(ItemID.OAK_PLANK, 1);
+                    }),
+            new OnXpDrop(Skill.MAGIC).onMenuOption("Cast").onMenuTarget(
+                    "Plank Make -> Teak logs").requiredItem(ItemID.PLANK_SACK).consumer(
+                    () -> {
+                        storage.add(ItemID.TEAK_PLANK, 1);
+                    }),
+            new OnXpDrop(Skill.MAGIC).onMenuOption("Cast").onMenuTarget(
+                    "Plank Make -> Mahogany logs").requiredItem(ItemID.PLANK_SACK).consumer(
+                    () -> {
+                        storage.add(ItemID.MAHOGANY_PLANK, 1);
+                    }),
+
             // Mahogany homes - 1 plank
             new OnXpDrop(Skill.CONSTRUCTION).xpAmountConsumer((xp) -> {
                 storage.removeAndPrioritizeInventory(getPlankIdBasedOnXpAndPlanks(xp, 1), 1);

--- a/src/main/java/tictac7x/charges/items/U_PlankSack.java
+++ b/src/main/java/tictac7x/charges/items/U_PlankSack.java
@@ -93,25 +93,13 @@ public class U_PlankSack extends ChargedItemWithStorage {
 
             // Plank Make on Log in Inventory
             new OnXpDrop(Skill.MAGIC).onMenuOption("Cast").onMenuTarget(
-                    "Plank Make -> Logs").requiredItem(ItemID.PLANK_SACK).consumer(
-                    () -> {
-                        storage.add(ItemID.PLANK, 1);
-                    }),
+                    "Plank Make -> Logs").requiredItem(ItemID.PLANK_SACK).addToStorage(ItemID.PLANK, 1),
             new OnXpDrop(Skill.MAGIC).onMenuOption("Cast").onMenuTarget(
-                    "Plank Make -> Oak logs").requiredItem(ItemID.PLANK_SACK).consumer(
-                    () -> {
-                        storage.add(ItemID.OAK_PLANK, 1);
-                    }),
+                    "Plank Make -> Oak logs").requiredItem(ItemID.PLANK_SACK).addToStorage(ItemID.OAK_PLANK, 1),
             new OnXpDrop(Skill.MAGIC).onMenuOption("Cast").onMenuTarget(
-                    "Plank Make -> Teak logs").requiredItem(ItemID.PLANK_SACK).consumer(
-                    () -> {
-                        storage.add(ItemID.TEAK_PLANK, 1);
-                    }),
+                    "Plank Make -> Teak logs").requiredItem(ItemID.PLANK_SACK).addToStorage(ItemID.TEAK_PLANK, 1),
             new OnXpDrop(Skill.MAGIC).onMenuOption("Cast").onMenuTarget(
-                    "Plank Make -> Mahogany logs").requiredItem(ItemID.PLANK_SACK).consumer(
-                    () -> {
-                        storage.add(ItemID.MAHOGANY_PLANK, 1);
-                    }),
+                    "Plank Make -> Mahogany logs").requiredItem(ItemID.PLANK_SACK).addToStorage(ItemID.MAHOGANY_PLANK, 1),
 
             // Mahogany homes - 1 plank
             new OnXpDrop(Skill.CONSTRUCTION).xpAmountConsumer((xp) -> {


### PR DESCRIPTION
Previously using Plank Make and having the plank go into the plank sack would not update the plank sack counters. Added functionality to update the plank sack when plank make is cast on any type of log that can make a plank. Also works on the subsequent automatic casts after casting once.

![ezgif-16c4d586e6af9c](https://github.com/user-attachments/assets/12bf89bb-fe0e-4690-8903-6914e7d57344)
