### PR TITLE
fix(dailies): Correct daily reset time for Miscellania favor

### DIFF
--- a/src/main/java/tictac7x/daily/dailies/KingdomOfMiscellania.java
+++ b/src/main/java/tictac7x/daily/dailies/KingdomOfMiscellania.java
@@ -12,9 +12,7 @@ import tictac7x.daily.common.DailyInfobox;
 import tictac7x.daily.TicTac7xDailyTasksPlugin;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 
@@ -60,7 +58,7 @@ public class KingdomOfMiscellania extends DailyInfobox {
         if (event.getVarbitId() != VARBIT_KINGDOM_APPROVAL) return;
         if (Arrays.stream(MISCELLANIA_REGIONS).noneMatch(region -> region == client.getLocalPlayer().getWorldLocation().getRegionID())) return;
 
-        configManager.setConfiguration(TicTac7xDailyTasksConfig.group, TicTac7xDailyTasksConfig.kingdom_of_miscellania_favor_date, LocalDateTime.now(timezone).format(DateTimeFormatter.ISO_LOCAL_DATE));
+        configManager.setConfiguration(TicTac7xDailyTasksConfig.group, TicTac7xDailyTasksConfig.kingdom_of_miscellania_favor_date, LocalDate.now(timezone).toString());
         configManager.setConfiguration(TicTac7xDailyTasksConfig.group, TicTac7xDailyTasksConfig.kingdom_of_miscellania_favor, event.getValue());
     }
 


### PR DESCRIPTION
Fixes an issue where favor decay occurred one hour early for users in daylight saving timezones.

The timestamp is now saved using `LocalDate.now(UTC)` to ensure the daily calculation is correctly synchronized with the 00:00 UTC game reset.