### PR TITLE
Prifddinas progress

### DIFF
--- a/src/main/java/tictac7x/rooftops/Overlay.java
+++ b/src/main/java/tictac7x/rooftops/Overlay.java
@@ -7,6 +7,8 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import tictac7x.rooftops.course.CoursesManager;
 import tictac7x.rooftops.course.Obstacle;
+import tictac7x.rooftops.course.Portal;
+import net.runelite.api.TileObject;
 
 import java.awt.BasicStroke;
 import java.awt.Color;
@@ -54,6 +56,15 @@ public class Overlay extends net.runelite.client.ui.overlay.Overlay {
         // Mark of graces.
         for (final Tile mark : coursesManager.getMarksOfGraces()) {
             renderShape(graphics, mark.getItemLayer().getCanvasTilePoly(), config.getMarkOfGraceColor());
+        }
+
+        // Portals
+        if (coursesManager.getCourse().isPresent()) {
+            for (final Portal portal : coursesManager.getCourse().get().portals) {
+                if (portal.getTileObject().isPresent()) {
+                    renderShape(graphics, portal.getTileObject().get().getClickbox(), config.getPortalColor());
+                }
+            }
         }
 
         return null;

--- a/src/main/java/tictac7x/rooftops/Overlay.java
+++ b/src/main/java/tictac7x/rooftops/Overlay.java
@@ -62,7 +62,14 @@ public class Overlay extends net.runelite.client.ui.overlay.Overlay {
         if (coursesManager.getCourse().isPresent()) {
             for (final Portal portal : coursesManager.getCourse().get().portals) {
                 if (portal.getTileObject().isPresent()) {
-                    renderShape(graphics, portal.getTileObject().get().getClickbox(), config.getPortalColor());
+                    TileObject obj = portal.getTileObject().get();
+                    Shape clickbox = obj.getClickbox();
+
+                    if (clickbox != null) {
+                        renderShape(graphics, clickbox, config.getPortalColor());
+                    } else {
+                        // Inactive portal: don't render
+                    }
                 }
             }
         }

--- a/src/main/java/tictac7x/rooftops/TicTac7xRooftopsConfig.java
+++ b/src/main/java/tictac7x/rooftops/TicTac7xRooftopsConfig.java
@@ -64,6 +64,8 @@ public interface TicTac7xRooftopsConfig extends Config {
 			section = obstacles
 		) default Color getObstacleStopColor() { return new Color(255, 0, 0, 80); }
 
+		
+
 	@ConfigSection(
 		name = "Marks of graces",
 		description = "Marks of graces",
@@ -86,4 +88,21 @@ public interface TicTac7xRooftopsConfig extends Config {
 			position = 2,
 			section = marks_of_graces
 		) default boolean showMarkOfGraceStop() { return true; }
+
+		@Alpha
+		@ConfigItem(
+			keyName = "portal_color",
+			name = "Portal color",
+			description = "Color of the portal highlights.",
+			position = 3,
+			section = marks_of_graces
+		) default Color getPortalColor() { return new Color(0, 150, 255, 80); }
+
+		@ConfigItem(
+			keyName = "show_portal_stops",
+			name = "Show portal stop obstacles",
+			description = "Show obstacles as a stop when a portal is present",
+			position = 4,
+			section = marks_of_graces
+		) default boolean showPortalStops() { return true; }
 }

--- a/src/main/java/tictac7x/rooftops/TicTac7xRooftopsPlugin.java
+++ b/src/main/java/tictac7x/rooftops/TicTac7xRooftopsPlugin.java
@@ -72,6 +72,7 @@ public class TicTac7xRooftopsPlugin extends Plugin {
 			new Ardougne(),
 
 			// Other.
+			new Prifddinas(),
 			new Varlamore(),
 			new ApeAtoll()
 		});

--- a/src/main/java/tictac7x/rooftops/TicTac7xRooftopsPlugin.java
+++ b/src/main/java/tictac7x/rooftops/TicTac7xRooftopsPlugin.java
@@ -22,7 +22,7 @@ import javax.inject.Inject;
 @Slf4j
 @PluginDescriptor(
 	name = "Rooftop Agility Improved",
-	description = "Improved clickboxes for rooftop agility courses",
+	description = "Improved es for rooftop agility courses",
 	tags = { "roof", "rooftop", "agility", "mark", "grace", "graceful" }
 )
 public class TicTac7xRooftopsPlugin extends Plugin {

--- a/src/main/java/tictac7x/rooftops/course/Course.java
+++ b/src/main/java/tictac7x/rooftops/course/Course.java
@@ -5,25 +5,53 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import net.runelite.api.coords.WorldPoint;  // Add this import
+
 public abstract class Course {
     public final String id;
     public final int[] regions;
     public final Obstacle[] obstacles;
     public final MarkOfGrace[] marksOfGraces;
+    public final Portal[] portals;
 
     private Optional<Obstacle> currentObstacle = Optional.empty();
     private boolean isDoingObstacle = false;
+    private boolean justUsedPortal = false;
 
+    
+    // Constructor for courses with marks of grace
     public Course(
         final String id,
         final int[] regions,
         final Obstacle[] obstacles,
         final MarkOfGrace[] marksOfGraces
     ) {
+        this(id, regions, obstacles, marksOfGraces, new Portal[0]);
+    }
+
+    // Constructor for courses with portals (like Prifddinas)
+    public Course(
+        final String id,
+        final int[] regions,
+        final Obstacle[] obstacles,
+        final Portal[] portals
+    ) {
+        this(id, regions, obstacles, new MarkOfGrace[0], portals);
+    }
+
+    // Full constructor
+    public Course(
+        final String id,
+        final int[] regions,
+        final Obstacle[] obstacles,
+        final MarkOfGrace[] marksOfGraces,
+        final Portal[] portals
+    ) {
         this.id = id;
         this.regions = regions;
         this.obstacles = obstacles;
         this.marksOfGraces = marksOfGraces;
+        this.portals = portals;
     }
 
     public Optional<Obstacle> getCurrentObstacle() {
@@ -44,9 +72,33 @@ public abstract class Course {
                     nextObstacles.add(obstacle);
                 }
             }
+        }
+        
+        // Check if player just used a portal
+        else if (justUsedPortal) {
+            // Find current obstacle index
+            int currentObstacleIndex = 0;
+            for (final Obstacle obstacle : obstacles) {
+                if (obstacle.id == currentObstacle.get().id) {
+                    break;
+                }
+                currentObstacleIndex++;
+            }
+
+            // Skip one obstacle (if possible)
+            if (currentObstacleIndex + 2 < obstacles.length) {
+                nextObstacles.add(obstacles[currentObstacleIndex + 2]);
+            } else if (currentObstacleIndex + 1 < obstacles.length) {
+                // If we can't skip two ahead, just use the next one
+                nextObstacles.add(obstacles[currentObstacleIndex + 1]);
+            }
+            
+            // Reset portal usage flag
+            justUsedPortal = false;
+        }
 
         // Find next obstacle index based on order.
-        } else {
+         else {
             int currentObstacleIndex = 0;
             for (final Obstacle obstacle : obstacles) {
                 if (obstacle.id == currentObstacle.get().id) {
@@ -127,5 +179,91 @@ public abstract class Course {
         for (final Obstacle obstacle : obstacles) {
             obstacle.clearTileObject();
         }
+    }
+    public void clearPortalTileObjects() {
+        for (final Portal portal : portals) {
+            portal.clearTileObject();
+        }
+    }
+
+    /**
+     * Call this method when a player uses a portal
+     * @param portalId The ID of the portal that was used
+     * @return true if a valid portal was used, false otherwise
+     */
+    public boolean usePortal(int portalId) {
+        // Find the portal by ID
+        for (Portal portal : portals) {
+            if (portal.id == portalId && portal.getTileObject().isPresent()) {
+                // If the portal specifies which obstacle to go to next, use that
+                if (portal.nextObstacles.isPresent() && !portal.nextObstacles.get().isEmpty()) {
+                    int nextObstacleId = portal.nextObstacles.get().get(0);
+                    
+                    // Find the obstacle with this ID and set it as current
+                    for (Obstacle obstacle : obstacles) {
+                        if (obstacle.id == nextObstacleId) {
+                            currentObstacle = Optional.of(obstacle);
+                            isDoingObstacle = false;
+                            
+                            // Clear the portal after use to prevent reuse
+                            portal.clearTileObject();
+                            return true;
+                        }
+                    }
+                }
+                
+                // Fallback to original behavior if no next obstacle is specified
+                justUsedPortal = true;
+                if (currentObstacle.isPresent()) {
+                    int currentIndex = -1;
+                    for (int i = 0; i < obstacles.length; i++) {
+                        if (obstacles[i].id == currentObstacle.get().id) {
+                            currentIndex = i;
+                            break;
+                        }
+                    }
+                    
+                    if (currentIndex >= 0 && currentIndex + 2 < obstacles.length) {
+                        currentObstacle = Optional.of(obstacles[currentIndex + 2]);
+                    } else if (currentIndex >= 0 && currentIndex + 1 < obstacles.length) {
+                        currentObstacle = Optional.of(obstacles[currentIndex + 1]);
+                    }
+                    isDoingObstacle = false;
+                }
+                
+                // Clear the portal after use to prevent reuse
+                portal.clearTileObject();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks if any portal is visible and close to the player
+     * @param playerLocation The player's current location
+     * @param maxDistance Maximum distance to consider a portal as close
+     * @return The portal that's close to the player, or empty if none are close
+     */
+    public Optional<Portal> findNearbyPortal(WorldPoint playerLocation, int maxDistance) {
+        if (playerLocation == null) return Optional.empty();
+        
+        for (Portal portal : portals) {
+            if (portal.getTileObject().isPresent()) {
+                for (WorldPoint portalLocation : portal.locations) {
+                    if (playerLocation.distanceTo(portalLocation) <= maxDistance) {
+                        return Optional.of(portal);
+                    }
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Resets the portal usage state
+     */
+    public void clearPortalUsage() {
+        justUsedPortal = false;
     }
 }

--- a/src/main/java/tictac7x/rooftops/course/Course.java
+++ b/src/main/java/tictac7x/rooftops/course/Course.java
@@ -207,6 +207,7 @@ public abstract class Course {
                             
                             // Clear the portal after use to prevent reuse
                             portal.clearTileObject();
+                            obstacle.clearTileObject();
                             return true;
                         }
                     }

--- a/src/main/java/tictac7x/rooftops/course/CoursesManager.java
+++ b/src/main/java/tictac7x/rooftops/course/CoursesManager.java
@@ -51,7 +51,7 @@ public class CoursesManager {
         // Check portals
         for (final Portal portal : course.get().portals) {
             portal.checkAndSetTileObject(tileObject);
-        }
+       }
     }
 
     public void onGameStateChanged(final GameStateChanged event) {
@@ -156,8 +156,9 @@ public class CoursesManager {
                 
                 // If we found the obstacle and player is close to a portal
                 if (currentObstacle != null) {
-                    Optional<Portal> nearbyPortal = course.get().findNearbyPortal(player.getWorldLocation(), 3);
-                    if (nearbyPortal.isPresent()) {
+                    Optional<Portal> nearbyPortal = course.get().findNearbyPortal(player.getWorldLocation(), 6);
+
+                    if (nearbyPortal.isPresent()&& nearbyPortal.get().getTileObject().get().getClickbox()!=null) {
                         return true;
                     }
                 }

--- a/src/main/java/tictac7x/rooftops/course/CoursesManager.java
+++ b/src/main/java/tictac7x/rooftops/course/CoursesManager.java
@@ -32,6 +32,7 @@ public class CoursesManager {
     private final Pattern regexLapComplete = Pattern.compile(".*lap count is:.*");
 
     private final List<Tile> marksOfGraces = new ArrayList<>();
+    private final List<TileObject> portalObjects = new ArrayList<>();
     private final List<Integer> menuOptionsClicked = new ArrayList<>();
     private Optional<Course> course = Optional.empty();
 
@@ -47,13 +48,21 @@ public class CoursesManager {
                 obstacle.checkAndSetTileObject(tileObject);
             }
         }
+        // Check portals
+        for (final Portal portal : course.get().portals) {
+            portal.checkAndSetTileObject(tileObject);
+        }
     }
 
     public void onGameStateChanged(final GameStateChanged event) {
         // Clear previous obstacles objects (since they will spawn again).
         if (event.getGameState() == GameState.LOADING) {
-            if (course.isPresent()) course.get().clearObstaclesTileObjects();
+            if (course.isPresent()) {
+                course.get().clearObstaclesTileObjects();
+                course.get().clearPortalTileObjects();
+            }
             marksOfGraces.clear();
+            portalObjects.clear();
             course = Optional.empty();
         }
     }
@@ -72,6 +81,19 @@ public class CoursesManager {
 
     public void onGameTick(final GameTick ignored) {
         checkStartObstacle();
+
+        // Check if player completed an obstacle by position (for obstacles that don't give XP)
+        if (course.isPresent() && course.get().getCurrentObstacle().isPresent() && course.get().isDoingObstacle()) {
+            Obstacle currentObstacle = course.get().getCurrentObstacle().get();
+            if (currentObstacle.completeAt.isPresent()) {
+                int[] completeAt = currentObstacle.completeAt.get();
+                WorldPoint playerLocation = client.getLocalPlayer().getWorldLocation();
+                
+                if (playerLocation.getX() == completeAt[0] && playerLocation.getY() == completeAt[1]) {
+                    completeObstacle(menuOptionsClicked);
+                }
+            }
+        }
     }
 
     public void onChatMessage(final ChatMessage event) {
@@ -118,6 +140,30 @@ public class CoursesManager {
                 }
             }
         }
+
+        // Check for portals near the player
+        if (config.showPortalStops()) {
+            Player player = client.getLocalPlayer();
+            if (player != null) {
+                // Find the current obstacle
+                Obstacle currentObstacle = null;
+                for (Obstacle obstacle : course.get().obstacles) {
+                    if (obstacle.id == obstacleId) {
+                        currentObstacle = obstacle;
+                        break;
+                    }
+                }
+                
+                // If we found the obstacle and player is close to a portal
+                if (currentObstacle != null) {
+                    Optional<Portal> nearbyPortal = course.get().findNearbyPortal(player.getWorldLocation(), 3);
+                    if (nearbyPortal.isPresent()) {
+                        return true;
+                    }
+                }
+            }
+        }
+        
 
         return false;
     }
@@ -203,6 +249,22 @@ public class CoursesManager {
 
     public void onMenuOptionClicked(final MenuOptionClicked event) {
         if (course.isPresent()) {
+            // Check if player clicked on a portal
+            for (final Portal portal : course.get().portals) {
+                if (portal.getTileObject().isPresent() && 
+                    event.getId() == portal.id) {
+                    // Player clicked a portal, mark it as used
+                    if (portal.nextObstacles.isPresent() && !portal.nextObstacles.get().isEmpty()) {
+                        int nextObstacleId = portal.nextObstacles.get().get(0);
+                        // Add the target obstacle ID to menuOptionsClicked
+                        menuOptionsClicked.add(nextObstacleId);
+                    }
+                    course.get().usePortal(portal.id);
+                    return;
+                }
+            }
+            
+            // Check if player clicked on an obstacle
             for (final Obstacle obstacle : course.get().obstacles) {
                 if (event.getId() == obstacle.id) {
                     menuOptionsClicked.add(event.getId());

--- a/src/main/java/tictac7x/rooftops/course/Portal.java
+++ b/src/main/java/tictac7x/rooftops/course/Portal.java
@@ -1,0 +1,44 @@
+package tictac7x.rooftops.course;
+
+import net.runelite.api.TileObject;
+import net.runelite.api.coords.WorldPoint;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class Portal {
+    public final int id;
+    public final List<WorldPoint> locations;
+    private Optional<TileObject> tileObject = Optional.empty();
+    public Optional<List<Integer>> nextObstacles = Optional.empty();
+
+    public Portal(final int id, final int plane, final int[][] locations) {
+        this.id = id;
+        this.locations = new ArrayList<>();
+        for (final int[] location : locations) {
+            this.locations.add(new WorldPoint(location[0], location[1], plane));
+        }
+    }
+
+    public void checkAndSetTileObject(final TileObject tileObject) {
+        if (tileObject.getId() == id) {
+            this.tileObject = Optional.of(tileObject);
+        }
+    }
+
+    public void clearTileObject() {
+        tileObject = Optional.empty();
+    }
+
+    public Optional<TileObject> getTileObject() {
+        return tileObject;
+    }
+    
+    public Portal nextObstacle(final int... ids) {
+        nextObstacles = Optional.of(Arrays.stream(ids).boxed().collect(Collectors.toList()));
+        return this;
+    }
+}

--- a/src/main/java/tictac7x/rooftops/course/Portal.java
+++ b/src/main/java/tictac7x/rooftops/course/Portal.java
@@ -1,5 +1,5 @@
 package tictac7x.rooftops.course;
-
+import net.runelite.api.Client;
 import net.runelite.api.TileObject;
 import net.runelite.api.coords.WorldPoint;
 

--- a/src/main/java/tictac7x/rooftops/courses/Prifddinas.java
+++ b/src/main/java/tictac7x/rooftops/courses/Prifddinas.java
@@ -40,7 +40,7 @@ public class Prifddinas extends Course {
 
            new Portal[]{ 
                 new Portal(36241, 2, new int[][]{{3257, 6111}}).nextObstacle(36225), // Portal on top of bank
-                new Portal(36242, 0, new int[][]{{3270, 6116}}).nextObstacle(36229), // Portal by Dark Hole in garden (or 36247?)
+                new Portal(36242, 0, new int[][]{{3270, 6116}}).nextObstacle(36231), // Portal by Dark Hole in garden (or 36247?)
                 new Portal(36243, 2, new int[][]{{2258, 3386}}).nextObstacle(36234), // Portal after first Rope Bridge
                 new Portal(36244, 2, new int[][]{{2243, 3395}}).nextObstacle(36235), // Portal before second Rope Bridge
                 new Portal(36245, 2, new int[][]{{2248, 3405}}).nextObstacle(36236), // Portal before Tightrope

--- a/src/main/java/tictac7x/rooftops/courses/Prifddinas.java
+++ b/src/main/java/tictac7x/rooftops/courses/Prifddinas.java
@@ -1,0 +1,51 @@
+package tictac7x.rooftops.courses;
+
+import tictac7x.rooftops.course.Course;
+import tictac7x.rooftops.course.Portal;
+import tictac7x.rooftops.course.Obstacle;
+
+public class Prifddinas extends Course {
+    public Prifddinas() {
+        super("Prifddinas",
+            // Regions.
+            new int[]{12895,13151,9012,9013},
+
+            // Obstacles.
+            new Obstacle[]{
+                new Obstacle(36221, 0, new int[][]{{3254, 6109}}), //Ladder (start of course)
+                new Obstacle(36225, 2, new int[][]{{3257, 6105}}), //Tightrope
+                new Obstacle(36227, 2, new int[][]{{3273, 6107}}), //Chimney
+                new Obstacle(36228, 2, new int[][]{{3269, 6116}}),
+                new Obstacle(36229, 0, new int[][]{{3269, 6118}}), //Dark Hole
+                new Obstacle(36231, 0, new int[][]{{2270, 3393}}).completeAt(2269, 3393).nextObstacle(36233), //Ladder (doesn't give exp)
+                new Obstacle(36233, 2, new int[][]{{2264, 3390}}), //Rope Bridge
+                new Obstacle(36234, 2, new int[][]{{2254, 3390}, {2253, 3390}}), //Tightrope
+                new Obstacle(36235, 2, new int[][]{{2246, 3399}}), //Rope Bridge
+                new Obstacle(36236, 2, new int[][]{{2244, 3409}, {2243, 3409}}), //Tightrope
+                new Obstacle(36237, 2, new int[][]{{2253, 3418}, {2254,3418}}), //Rope Bridge
+                new Obstacle(36238, 0, new int[][]{{2258, 3432}}), //Dark Hole
+
+                //new Obstacle(36232, 0, new int[][]{{3267, 6145}}), //Ladder when failing Tightrope, not sure how to implement this? Also very hard to test...
+            },
+
+            /*
+            new Portal[]{ // Portals
+                new Portal(3257, 6111, 36241), // Portal on top of bank
+                new Portal(3270, 6116, 36247), // Portal by Dark Hole in garden
+                new Portal(2258, 3386, 36243), // Portal after first Rope Bridge
+                new Portal(2243, 3395, 36244), // Portal before second Rope Bridge
+                new Portal(2249, 3419, 36246), // Portal before final Tightrope
+            }
+            */
+
+           new Portal[]{ 
+                new Portal(36241, 2, new int[][]{{3257, 6111}}).nextObstacle(36225), // Portal on top of bank
+                new Portal(36242, 0, new int[][]{{3270, 6116}}).nextObstacle(36229), // Portal by Dark Hole in garden (or 36247?)
+                new Portal(36243, 2, new int[][]{{2258, 3386}}).nextObstacle(36234), // Portal after first Rope Bridge
+                new Portal(36244, 2, new int[][]{{2243, 3395}}).nextObstacle(36235), // Portal before second Rope Bridge
+                new Portal(36245, 2, new int[][]{{2248, 3405}}).nextObstacle(36236), // Portal before Tightrope
+                new Portal(36246, 2, new int[][]{{2249, 3419}}).nextObstacle(36237), // Portal before final Tightrope
+           }
+        );
+    }
+}


### PR DESCRIPTION
My coding knowledge is EXTREMELY limited but I came up with a few fixes with the help of a friend. All these changes were made on Melleni's pull request. I don't really know how git works so I hope this ends up in the correct place.

**Fixes**
Fixed portal behavior
Fixed stop obstacle behavior

**To do:**
**1-** Portals instantly have clickable color even though player is in an animation/can't interact with portal yet.
**2-** When a portal is clicked on, the next obstacle is instantly colored as interactable even though the portal action isn't complete.
**3-** Third failable obstacle.
**4-** The portal check relies on player distance, this makes the timing where obstacle_stop is drawn inconsistent.
**5-** Obstacles change color before you interact with them. So if you red click an obstacle and reach it, but cancel the action by moving away from the last tile, it acts as if you've already interacted with it, highlighting the next obstacle. This issue seems to be present across all rooftop courses.

**Possible fixes:**
**1-** Classify portals similar to how obstacles are handled
**2-** When a portal is clicked on, wait for player to hit certain coordinates before drawing the next obstacle as clickable.
Player coords after each portal:
36241=3275, 6105, 2
36242=2268, 3389, 2
36243=2244, 3394, 2
36244=2247, 3405, 2
36245=2253, 3415, 2
36246=2262, 3426, 0
**3-** Each time a hitsplat is rendered, put an if statement checking the player coordinate. If the coordinate is the tile where you drop from the 3rd failable obstacle (3275, 6146, 0), highlight the ladder (ID=36232). Else completeCourse(); , highlighting the first obstacle.
**4-** No clue really.
**5-** Not sure if this is the efficient way but, the code could check player coords after each obstacle before hiding/coloring obstacles. Or if there's another way to check if the obstacle is completed, that would work too.

