### PR TITLE
Update Alchemists Amulet to support 1 charge case

### DIFF
--- a/src/main/java/tictac7x/charges/items/jewelry/J_AlchemistsAmulet.java
+++ b/src/main/java/tictac7x/charges/items/jewelry/J_AlchemistsAmulet.java
@@ -19,7 +19,7 @@ public class J_AlchemistsAmulet extends ChargedItem {
 
         this.triggers.addAll(List.of(
             // Check
-            new OnChatMessage("Your Alchemist's amulet has (?<charges>.+) charges left.").setDynamicallyCharges(),
+            new OnChatMessage("Your Alchemist's amulet has (?<charges>.+) charges? left.").setDynamicallyCharges(),
 
             // Charge
             new OnChatMessage("You apply an additional .+ charges to your Alchemist's amulet. It now has (?<charges>.+) charges in total.").setDynamicallyCharges(),
@@ -30,6 +30,7 @@ public class J_AlchemistsAmulet extends ChargedItem {
 
             // Use charge
             new OnChatMessage("Your Alchemist's amulet helps you create a .-dose potion. It no longer has any charges.").setFixedCharges(0),
+            new OnChatMessage("Your Alchemist's amulet helps you create a .-dose potion. It has one charge left.").setFixedCharges(1),
             new OnChatMessage("Your Alchemist's amulet helps you create a .-dose potion. It has (?<charges>.+) charges? left.").setDynamicallyCharges(),
 
             // Auto-charge


### PR DESCRIPTION
Alchemists Amulet with a singular charge has a unique message. I'm not sure if the coloring is stripped or not. If not then the fixed charge case won't match.

<img width="1306" height="430" alt="image" src="https://github.com/user-attachments/assets/b7e053a9-812c-4647-b865-7a08bc5f75b4" />
