### PR TITLE
feat: Add support for Abyssal tentacle charges (#505)

### DIFF
--- a/src/main/java/tictac7x/charges/TicTac7xChargesImprovedConfig.java
+++ b/src/main/java/tictac7x/charges/TicTac7xChargesImprovedConfig.java
@@ -166,6 +166,7 @@ public interface TicTac7xChargesImprovedConfig extends Config {
     String waterskin = "waterskin";
 
     // Weapons
+    String abyssal_tentacle = "abyssal_tentacle";
     String arclight = "arclight";
     String blazing_blowpipe = "blazing_blowpipe";
     String bow_of_faerdhinen = "bow_of_faerdhinen";
@@ -1299,6 +1300,13 @@ public interface TicTac7xChargesImprovedConfig extends Config {
                 section = infoboxes
         ) default boolean eyeOfAyakInfobox() { return true; }
 
+        @ConfigItem(
+            keyName = abyssal_tentacle + _infobox,
+            name = "Abyssal tentacle",
+            description = "",
+            section = infoboxes
+        ) default boolean abyssalTentacleInfobox() { return true; }
+
     @ConfigSection(
         name = "Overlays",
         description = "Choose for which charged items number is shown next to it",
@@ -2202,6 +2210,13 @@ public interface TicTac7xChargesImprovedConfig extends Config {
                 section = overlays
         ) default boolean eyeOfAyakOverlay() { return true; }
 
+        @ConfigItem(
+            keyName = abyssal_tentacle + _overlay,
+            name = "Abyssal tentacle",
+            description = "",
+            section = overlays
+        ) default boolean abyssalTentacleOverlay() { return true; }
+
     @ConfigSection(
         name = "Debug",
         description = "Values of charges for all items under the hood",
@@ -2828,4 +2843,11 @@ public interface TicTac7xChargesImprovedConfig extends Config {
             description = amulet_of_chemistry,
             section = debug
         ) default int getAmuletOfChemistryCharges() { return ChargeId.UNKNOWN; }
+
+        @ConfigItem(
+            keyName = abyssal_tentacle,
+            name = abyssal_tentacle,
+            description = abyssal_tentacle,
+            section = debug
+        ) default int getAbyssalTentacleCharges() { return ChargeId.UNKNOWN; }
 }

--- a/src/main/java/tictac7x/charges/TicTac7xChargesImprovedPlugin.java
+++ b/src/main/java/tictac7x/charges/TicTac7xChargesImprovedPlugin.java
@@ -478,6 +478,7 @@ public class TicTac7xChargesImprovedPlugin extends Plugin implements KeyListener
 			new U_Waterskin(provider),
 
 			// Weapons
+            new W_AbyssalTentacle(provider),
 			new W_Arclight(provider),
 			new W_BlazingBlowpipe(provider),
 			new W_BowOfFaerdhinen(provider),

--- a/src/main/java/tictac7x/charges/items/weapons/W_AbyssalTentacle.java
+++ b/src/main/java/tictac7x/charges/items/weapons/W_AbyssalTentacle.java
@@ -1,0 +1,32 @@
+package tictac7x.charges.items.weapons;
+
+import java.util.List;
+import tictac7x.charges.TicTac7xChargesImprovedConfig;
+import tictac7x.charges.item.ChargedItem;
+import tictac7x.charges.item.triggers.OnAnimationChanged;
+import tictac7x.charges.item.triggers.OnChatMessage;
+import tictac7x.charges.item.triggers.OnGraphicChanged;
+import tictac7x.charges.item.triggers.TriggerItem;
+import tictac7x.charges.store.Provider;
+import tictac7x.charges.store.ids.ItemId;
+
+public class W_AbyssalTentacle extends ChargedItem {
+    public W_AbyssalTentacle(final Provider provider) {
+        super(TicTac7xChargesImprovedConfig.abyssal_tentacle, ItemId.ABYSSAL_TENTACLE, provider);
+
+        this.items = new TriggerItem[]{
+            new TriggerItem(ItemId.ABYSSAL_TENTACLE)
+        };
+
+        this.triggers.addAll(List.of(
+            // Check.
+            new OnChatMessage("Your abyssal tentacle can perform (?<charges>.+) more attacks").setDynamicallyCharges(),
+
+            // Attack.
+            new OnAnimationChanged(1658).itemEquipped(ItemId.ABYSSAL_TENTACLE).decreaseCharges(1),
+
+            // Degrade
+            new OnChatMessage("Your abyssal tentacle has degraded.").setFixedCharges(0)
+        ));
+    }
+}

--- a/src/main/java/tictac7x/charges/items/weapons/W_AbyssalTentacle.java
+++ b/src/main/java/tictac7x/charges/items/weapons/W_AbyssalTentacle.java
@@ -5,7 +5,6 @@ import tictac7x.charges.TicTac7xChargesImprovedConfig;
 import tictac7x.charges.item.ChargedItem;
 import tictac7x.charges.item.triggers.OnAnimationChanged;
 import tictac7x.charges.item.triggers.OnChatMessage;
-import tictac7x.charges.item.triggers.OnGraphicChanged;
 import tictac7x.charges.item.triggers.TriggerItem;
 import tictac7x.charges.store.Provider;
 import tictac7x.charges.store.ids.ItemId;
@@ -20,10 +19,10 @@ public class W_AbyssalTentacle extends ChargedItem {
 
         this.triggers.addAll(List.of(
             // Check.
-            new OnChatMessage("Your abyssal tentacle can perform (?<charges>.+) more attacks").setDynamicallyCharges(),
+            new OnChatMessage("Your abyssal tentacle can perform (?<charges>.+) more attacks?").setDynamicallyCharges(),
 
             // Attack.
-            new OnAnimationChanged(1658).itemEquipped(ItemId.ABYSSAL_TENTACLE).decreaseCharges(1),
+            new OnAnimationChanged(1658).itemEquipped().decreaseCharges(1),
 
             // Degrade
             new OnChatMessage("Your abyssal tentacle has degraded.").setFixedCharges(0)

--- a/src/main/java/tictac7x/charges/store/ids/ItemId.java
+++ b/src/main/java/tictac7x/charges/store/ids/ItemId.java
@@ -1441,6 +1441,9 @@ public final class ItemId {
     public static final int WATERSKIN_3 = ItemID.WATER_SKIN3;
     public static final int WATERSKIN_4 = ItemID.WATER_SKIN4;
 
+    // Abyssal Tentacle Whip
+    public static final int ABYSSAL_TENTACLE = ItemID.ABYSSAL_TENTACLE;
+
     // Arclight
     public static final int ARCLIGHT = ItemID.ARCLIGHT;
     public static final int ARCLIGHT_UNCHARGED = ItemID.ARCLIGHT_INACTIVE;


### PR DESCRIPTION
- Adds support for tracking the charges of the Abyssal tentacle

_I didn't update the version, so either do so yourself if/when you merge the PR(s) or I can bump for you. I wasn't sure how you'd like to proceed._

Closes #505 

https://github.com/user-attachments/assets/57f2bde0-2570-44d1-9c99-7ae528c29f3e


