### PR TITLE
feat: Add support for the Serpentine Helm (#429)

### DIFF
--- a/src/main/java/tictac7x/charges/TicTac7xChargesImprovedConfig.java
+++ b/src/main/java/tictac7x/charges/TicTac7xChargesImprovedConfig.java
@@ -51,6 +51,7 @@ public interface TicTac7xChargesImprovedConfig extends Config {
     // Helms
     String circlet_of_water = "circlet_of_water";
     String kandarin_headgear = "kandarin_headgear";
+    String serpentine_helm = "serpentine_helm";
 
     // Boots
     String fremennik_sea_boots = "fremennik_sea_boots";
@@ -1299,6 +1300,13 @@ public interface TicTac7xChargesImprovedConfig extends Config {
                 section = infoboxes
         ) default boolean eyeOfAyakInfobox() { return true; }
 
+    @ConfigItem(
+        keyName = serpentine_helm + _infobox,
+        name = "Serpentine helm",
+        description = "",
+        section = infoboxes
+    ) default boolean serpentineHelmInfobox() { return true; }
+
     @ConfigSection(
         name = "Overlays",
         description = "Choose for which charged items number is shown next to it",
@@ -2202,6 +2210,13 @@ public interface TicTac7xChargesImprovedConfig extends Config {
                 section = overlays
         ) default boolean eyeOfAyakOverlay() { return true; }
 
+        @ConfigItem(
+            keyName = serpentine_helm + _overlay,
+            name = "Serpentine helm",
+            description = "",
+            section = overlays
+        ) default boolean serpentineHelmOverlay() { return true; }
+
     @ConfigSection(
         name = "Debug",
         description = "Values of charges for all items under the hood",
@@ -2828,4 +2843,11 @@ public interface TicTac7xChargesImprovedConfig extends Config {
             description = amulet_of_chemistry,
             section = debug
         ) default int getAmuletOfChemistryCharges() { return ChargeId.UNKNOWN; }
+
+        @ConfigItem(
+            keyName = serpentine_helm,
+            name = serpentine_helm,
+            description = serpentine_helm,
+            section = debug
+        ) default int getSerpentineHelmCharges() { return ChargeId.UNKNOWN; }
 }

--- a/src/main/java/tictac7x/charges/TicTac7xChargesImprovedConfig.java
+++ b/src/main/java/tictac7x/charges/TicTac7xChargesImprovedConfig.java
@@ -52,6 +52,8 @@ public interface TicTac7xChargesImprovedConfig extends Config {
     String circlet_of_water = "circlet_of_water";
     String kandarin_headgear = "kandarin_headgear";
     String serpentine_helm = "serpentine_helm";
+    String magma_helm = "magma_helm";
+    String tanzanite_helm = "tanzanite_helm";
 
     // Boots
     String fremennik_sea_boots = "fremennik_sea_boots";
@@ -1307,6 +1309,20 @@ public interface TicTac7xChargesImprovedConfig extends Config {
         section = infoboxes
     ) default boolean serpentineHelmInfobox() { return true; }
 
+    @ConfigItem(
+        keyName = magma_helm + _infobox,
+        name = "Magma helm",
+        description = "",
+        section = infoboxes
+    ) default boolean magmaHelmInfobox() { return true; }
+
+    @ConfigItem(
+        keyName = tanzanite_helm + _infobox,
+        name = "Tanzanite helm",
+        description = "",
+        section = infoboxes
+    ) default boolean tanzaniteHelmInfobox() { return true; }
+
     @ConfigSection(
         name = "Overlays",
         description = "Choose for which charged items number is shown next to it",
@@ -2217,6 +2233,20 @@ public interface TicTac7xChargesImprovedConfig extends Config {
             section = overlays
         ) default boolean serpentineHelmOverlay() { return true; }
 
+        @ConfigItem(
+            keyName = magma_helm + _overlay,
+            name = "Magma helm",
+            description = "",
+            section = overlays
+        ) default boolean magmaHelmOverlay() { return true; }
+
+        @ConfigItem(
+            keyName = tanzanite_helm + _overlay,
+            name = "Tanzanite helm",
+            description = "",
+            section = overlays
+        ) default boolean tanzaniteHelmOverlay() { return true; }
+
     @ConfigSection(
         name = "Debug",
         description = "Values of charges for all items under the hood",
@@ -2850,4 +2880,18 @@ public interface TicTac7xChargesImprovedConfig extends Config {
             description = serpentine_helm,
             section = debug
         ) default int getSerpentineHelmCharges() { return ChargeId.UNKNOWN; }
+
+        @ConfigItem(
+            keyName = magma_helm,
+            name = magma_helm,
+            description = magma_helm,
+            section = debug
+        ) default int getMagmaHelmCharges() { return ChargeId.UNKNOWN; }
+
+    @ConfigItem(
+        keyName = tanzanite_helm,
+        name = tanzanite_helm,
+        description = tanzanite_helm,
+        section = debug
+    ) default int getTanzaniteHelmCharges() { return ChargeId.UNKNOWN; }
 }

--- a/src/main/java/tictac7x/charges/TicTac7xChargesImprovedPlugin.java
+++ b/src/main/java/tictac7x/charges/TicTac7xChargesImprovedPlugin.java
@@ -251,6 +251,7 @@ public class TicTac7xChargesImprovedPlugin extends Plugin implements KeyListener
 			// Helms
 			new H_CircletOfWater(provider),
 			new H_KandarinHeadgear(provider),
+            new H_SerpentineHelm(provider),
 
 			// Jewelery
 			new J_AlchemistsAmulet(provider),

--- a/src/main/java/tictac7x/charges/TicTac7xChargesImprovedPlugin.java
+++ b/src/main/java/tictac7x/charges/TicTac7xChargesImprovedPlugin.java
@@ -252,6 +252,8 @@ public class TicTac7xChargesImprovedPlugin extends Plugin implements KeyListener
 			new H_CircletOfWater(provider),
 			new H_KandarinHeadgear(provider),
             new H_SerpentineHelm(provider),
+            new H_MagmaHelm(provider),
+            new H_TanzaniteHelm(provider),
 
 			// Jewelery
 			new J_AlchemistsAmulet(provider),

--- a/src/main/java/tictac7x/charges/items/helms/H_MagmaHelm.java
+++ b/src/main/java/tictac7x/charges/items/helms/H_MagmaHelm.java
@@ -1,0 +1,19 @@
+package tictac7x.charges.items.helms;
+
+import tictac7x.charges.TicTac7xChargesImprovedConfig;
+import tictac7x.charges.item.triggers.TriggerItem;
+import tictac7x.charges.store.Provider;
+import tictac7x.charges.store.ids.ItemId;
+
+public class H_MagmaHelm extends H_SerpentineHelm
+{
+	public H_MagmaHelm(final Provider provider)
+	{
+		super(TicTac7xChargesImprovedConfig.magma_helm, ItemId.SERPENTINE_MAGMA_HELM, provider);
+
+		this.items = new TriggerItem[]{
+			new TriggerItem(ItemId.SERPENTINE_MAGMA_HELM_UNCHARGED).fixedCharges(0),
+			new TriggerItem(ItemId.SERPENTINE_MAGMA_HELM)
+		};
+	}
+}

--- a/src/main/java/tictac7x/charges/items/helms/H_MagmaHelm.java
+++ b/src/main/java/tictac7x/charges/items/helms/H_MagmaHelm.java
@@ -5,15 +5,11 @@ import tictac7x.charges.item.triggers.TriggerItem;
 import tictac7x.charges.store.Provider;
 import tictac7x.charges.store.ids.ItemId;
 
-public class H_MagmaHelm extends H_SerpentineHelm
-{
-	public H_MagmaHelm(final Provider provider)
-	{
-		super(TicTac7xChargesImprovedConfig.magma_helm, ItemId.SERPENTINE_MAGMA_HELM, provider);
-
-		this.items = new TriggerItem[]{
-			new TriggerItem(ItemId.SERPENTINE_MAGMA_HELM_UNCHARGED).fixedCharges(0),
-			new TriggerItem(ItemId.SERPENTINE_MAGMA_HELM)
-		};
-	}
+public class H_MagmaHelm extends H_SerpentineHelm {
+    public H_MagmaHelm(final Provider provider) {
+        super(TicTac7xChargesImprovedConfig.magma_helm, ItemId.SERPENTINE_MAGMA_HELM, new TriggerItem[]{
+            new TriggerItem(ItemId.SERPENTINE_MAGMA_HELM_UNCHARGED).fixedCharges(0),
+            new TriggerItem(ItemId.SERPENTINE_MAGMA_HELM)
+        }, provider);
+    }
 }

--- a/src/main/java/tictac7x/charges/items/helms/H_SerpentineHelm.java
+++ b/src/main/java/tictac7x/charges/items/helms/H_SerpentineHelm.java
@@ -15,53 +15,49 @@ import tictac7x.charges.item.triggers.TriggerItem;
 import tictac7x.charges.store.Provider;
 import tictac7x.charges.store.ids.ItemId;
 
-public class H_SerpentineHelm extends ChargedItemWithStorage
-{
-	public H_SerpentineHelm(final Provider provider)
-	{
-		this(TicTac7xChargesImprovedConfig.serpentine_helm, ItemId.SERPENTINE_HELM, provider);
+public class H_SerpentineHelm extends ChargedItemWithStorage {
+    public H_SerpentineHelm(final Provider provider) {
+        this(TicTac7xChargesImprovedConfig.serpentine_helm, ItemId.SERPENTINE_HELM, new TriggerItem[]{
+            new TriggerItem(ItemId.SERPENTINE_HELM_UNCHARGED).fixedCharges(0),
+            new TriggerItem(ItemId.SERPENTINE_HELM)
+        }, provider);
+    }
 
-		this.items = new TriggerItem[]{
-			new TriggerItem(ItemId.SERPENTINE_HELM_UNCHARGED).fixedCharges(0),
-			new TriggerItem(ItemId.SERPENTINE_HELM)
-		};
-	}
+    public H_SerpentineHelm(final String configKey, final int itemId, final TriggerItem[] items, final Provider provider) {
+        super(configKey, itemId, provider);
 
-	public H_SerpentineHelm(final String configKey, final int itemId, final Provider provider)
-	{
-		super(configKey, itemId, provider);
+        this.items = items;
 
-		this.storage.storableItems(
-			new StorableItem(ItemId.ZULRAH_SCALES)
-		);
+        this.storage.storableItems(
+            new StorableItem(ItemId.ZULRAH_SCALES)
+        );
 
-		this.triggers.addAll(List.of(
-			// Check
-			new OnChatMessage("Scales: (?<scales>.+) \\(.*\\)").onItemClick().matcherConsumer(m -> {
-				final StorageItem scales = new StorageItem(ItemId.ZULRAH_SCALES, TicTac7xChargesImprovedPlugin.getNumberFromCommaString(m.group("scales")));
-				storage.clearAndPut(scales);
-			}),
+        this.triggers.addAll(List.of(
+            // Check
+            new OnChatMessage("Scales: (?<scales>.+) \\(.*\\)").onItemClick().matcherConsumer(m -> {
+                final StorageItem scales = new StorageItem(ItemId.ZULRAH_SCALES, TicTac7xChargesImprovedPlugin.getNumberFromCommaString(m.group("scales")));
+                storage.clearAndPut(scales);
+            }),
 
-			// Uncharge
-			new OnScriptPreFired(1651).scriptConsumer((script) -> {
-				final Optional<Widget> widget = TicTac7xChargesImprovedPlugin.getWidget(provider.client, 584, 5);
-				if (
-					widget.isPresent() &&
-						widget.get().getItemId() == this.itemId &&
-						script.getScriptEvent().getArguments().length >= 5 &&
-						script.getScriptEvent().getArguments()[4].toString().equals("Yes")
-				)
-				{
-					provider.store.addConsumerToNextTickQueue(() -> storage.clear());
-				}
-			}),
+            // Uncharge
+            new OnScriptPreFired(1651).scriptConsumer((script) -> {
+                final Optional<Widget> widget = TicTac7xChargesImprovedPlugin.getWidget(provider.client, 584, 5);
+                if (
+                    widget.isPresent() &&
+                        widget.get().getItemId() == this.itemId &&
+                        script.getScriptEvent().getArguments().length >= 5 &&
+                        script.getScriptEvent().getArguments()[4].toString().equals("Yes")
+                ) {
+                    provider.store.addConsumerToNextTickQueue(() -> storage.clear());
+                }
+            }),
 
-			// Degrade in combat - Note that this may always be off by 10 because the moment the player is in combat it consumes 10 scales, and then 10 every 90 ticks
-			// But the exact timing is not known for the "grace" period on the initial consumption. Therefore, I won't account for that initial consumption
-			new OnCombat(90).isEquipped().consumer(() -> storage.remove(ItemId.ZULRAH_SCALES, 10)),
+            // Degrade in combat - Note that this may always be off by 10 because the moment the player is in combat it consumes 10 scales, and then 10 every 90 ticks
+            // But the exact timing is not known for the "grace" period on the initial consumption. Therefore, I won't account for that initial consumption
+            new OnCombat(90).isEquipped().consumer(() -> storage.remove(ItemId.ZULRAH_SCALES, 10)),
 
-			// Ran out of charges upon degrading in combat
-			new OnChatMessage("Your serpentine helm has run out of Zulrah's scales.").matcherConsumer(m -> storage.clear())
-		));
-	}
+            // Ran out of charges upon degrading in combat
+            new OnChatMessage("Your serpentine helm has run out of Zulrah's scales.").consumer(() -> storage.clear())
+        ));
+    }
 }

--- a/src/main/java/tictac7x/charges/items/helms/H_SerpentineHelm.java
+++ b/src/main/java/tictac7x/charges/items/helms/H_SerpentineHelm.java
@@ -1,0 +1,72 @@
+package tictac7x.charges.items.helms;
+
+import java.util.List;
+import java.util.Optional;
+import net.runelite.api.widgets.Widget;
+import tictac7x.charges.TicTac7xChargesImprovedConfig;
+import tictac7x.charges.TicTac7xChargesImprovedPlugin;
+import tictac7x.charges.item.ChargedItemWithStorage;
+import tictac7x.charges.item.storage.StorableItem;
+import tictac7x.charges.item.storage.StorageItem;
+import tictac7x.charges.item.triggers.OnChatMessage;
+import tictac7x.charges.item.triggers.OnCombat;
+import tictac7x.charges.item.triggers.OnScriptPreFired;
+import tictac7x.charges.item.triggers.TriggerItem;
+import tictac7x.charges.store.Provider;
+import tictac7x.charges.store.ids.ItemId;
+
+public class H_SerpentineHelm extends ChargedItemWithStorage
+{
+	public H_SerpentineHelm(final Provider provider)
+	{
+		super(TicTac7xChargesImprovedConfig.serpentine_helm, ItemId.SERPENTINE_HELM, provider);
+
+		this.storage.storableItems(
+			new StorableItem(ItemId.ZULRAH_SCALES)
+		);
+
+		this.items = new TriggerItem[]{
+			new TriggerItem(ItemId.SERPENTINE_HELM),
+			new TriggerItem(ItemId.SERPENTINE_HELM_UNCHARGED).fixedCharges(0),
+			new TriggerItem(ItemId.SERPENTINE_MAGMA_HELM),
+			new TriggerItem(ItemId.SERPENTINE_MAGMA_HELM_UNCHARGED).fixedCharges(0),
+			new TriggerItem(ItemId.SERPENTINE_TANZANITE_HELM),
+			new TriggerItem(ItemId.SERPENTINE_TANZANITE_HELM_UNCHARGED).fixedCharges(0)
+		};
+
+		this.triggers.addAll(List.of(
+			// Check
+			new OnChatMessage("Scales: (?<scales>.+) \\(.*\\)").onItemClick().matcherConsumer(m -> {
+				final StorageItem scales = new StorageItem(ItemId.ZULRAH_SCALES, TicTac7xChargesImprovedPlugin.getNumberFromCommaString(m.group("scales")));
+				storage.clearAndPut(scales);
+			}),
+
+			// Uncharge
+			new OnScriptPreFired(1651).scriptConsumer((script) -> {
+				final Optional<Widget> widget = TicTac7xChargesImprovedPlugin.getWidget(provider.client, 584, 5);
+				if (
+					widget.isPresent() &&
+						widget.get().getItemId() == ItemId.SERPENTINE_HELM &&
+						script.getScriptEvent().getArguments().length >= 5 &&
+						script.getScriptEvent().getArguments()[4].toString().equals("Yes")
+				)
+				{
+					provider.store.addConsumerToNextTickQueue(() -> storage.clear());
+				}
+			}),
+
+			// Degrade in combat - Note that this may always be off by 10 because the moment the player is in combat it consumes 10 scales, and then 10 every 90 ticks
+			// But the exact timing is not known for the "grace" period on the initial consumption. Therefore, I won't account for that initial consumption
+			new OnCombat(90).isEquipped().consumer(() -> {
+				final Optional<StorageItem> scales = this.storage.getStorage().getItem(ItemId.ZULRAH_SCALES);
+				if (scales.isPresent() && scales.get().getQuantity() > 0)
+				{
+					scales.get().decreaseQuantity(10);
+				}
+			}),
+
+			// Ran out of charges upon degrading in combat
+			new OnChatMessage("Your serpentine helm has run out of Zulrah's scales.").matcherConsumer(m -> storage.clear())
+		));
+	}
+}

--- a/src/main/java/tictac7x/charges/items/helms/H_SerpentineHelm.java
+++ b/src/main/java/tictac7x/charges/items/helms/H_SerpentineHelm.java
@@ -19,20 +19,21 @@ public class H_SerpentineHelm extends ChargedItemWithStorage
 {
 	public H_SerpentineHelm(final Provider provider)
 	{
-		super(TicTac7xChargesImprovedConfig.serpentine_helm, ItemId.SERPENTINE_HELM, provider);
+		this(TicTac7xChargesImprovedConfig.serpentine_helm, ItemId.SERPENTINE_HELM, provider);
+
+		this.items = new TriggerItem[]{
+			new TriggerItem(ItemId.SERPENTINE_HELM_UNCHARGED).fixedCharges(0),
+			new TriggerItem(ItemId.SERPENTINE_HELM)
+		};
+	}
+
+	public H_SerpentineHelm(final String configKey, final int itemId, final Provider provider)
+	{
+		super(configKey, itemId, provider);
 
 		this.storage.storableItems(
 			new StorableItem(ItemId.ZULRAH_SCALES)
 		);
-
-		this.items = new TriggerItem[]{
-			new TriggerItem(ItemId.SERPENTINE_HELM),
-			new TriggerItem(ItemId.SERPENTINE_HELM_UNCHARGED).fixedCharges(0),
-			new TriggerItem(ItemId.SERPENTINE_MAGMA_HELM),
-			new TriggerItem(ItemId.SERPENTINE_MAGMA_HELM_UNCHARGED).fixedCharges(0),
-			new TriggerItem(ItemId.SERPENTINE_TANZANITE_HELM),
-			new TriggerItem(ItemId.SERPENTINE_TANZANITE_HELM_UNCHARGED).fixedCharges(0)
-		};
 
 		this.triggers.addAll(List.of(
 			// Check
@@ -46,7 +47,7 @@ public class H_SerpentineHelm extends ChargedItemWithStorage
 				final Optional<Widget> widget = TicTac7xChargesImprovedPlugin.getWidget(provider.client, 584, 5);
 				if (
 					widget.isPresent() &&
-						widget.get().getItemId() == ItemId.SERPENTINE_HELM &&
+						widget.get().getItemId() == this.itemId &&
 						script.getScriptEvent().getArguments().length >= 5 &&
 						script.getScriptEvent().getArguments()[4].toString().equals("Yes")
 				)
@@ -57,13 +58,7 @@ public class H_SerpentineHelm extends ChargedItemWithStorage
 
 			// Degrade in combat - Note that this may always be off by 10 because the moment the player is in combat it consumes 10 scales, and then 10 every 90 ticks
 			// But the exact timing is not known for the "grace" period on the initial consumption. Therefore, I won't account for that initial consumption
-			new OnCombat(90).isEquipped().consumer(() -> {
-				final Optional<StorageItem> scales = this.storage.getStorage().getItem(ItemId.ZULRAH_SCALES);
-				if (scales.isPresent() && scales.get().getQuantity() > 0)
-				{
-					scales.get().decreaseQuantity(10);
-				}
-			}),
+			new OnCombat(90).isEquipped().consumer(() -> storage.remove(ItemId.ZULRAH_SCALES, 10)),
 
 			// Ran out of charges upon degrading in combat
 			new OnChatMessage("Your serpentine helm has run out of Zulrah's scales.").matcherConsumer(m -> storage.clear())

--- a/src/main/java/tictac7x/charges/items/helms/H_TanzaniteHelm.java
+++ b/src/main/java/tictac7x/charges/items/helms/H_TanzaniteHelm.java
@@ -1,0 +1,19 @@
+package tictac7x.charges.items.helms;
+
+import tictac7x.charges.TicTac7xChargesImprovedConfig;
+import tictac7x.charges.item.triggers.TriggerItem;
+import tictac7x.charges.store.Provider;
+import tictac7x.charges.store.ids.ItemId;
+
+public class H_TanzaniteHelm extends H_SerpentineHelm
+{
+	public H_TanzaniteHelm(final Provider provider)
+	{
+		super(TicTac7xChargesImprovedConfig.tanzanite_helm, ItemId.SERPENTINE_TANZANITE_HELM, provider);
+
+		this.items = new TriggerItem[]{
+			new TriggerItem(ItemId.SERPENTINE_TANZANITE_HELM_UNCHARGED).fixedCharges(0),
+			new TriggerItem(ItemId.SERPENTINE_TANZANITE_HELM)
+		};
+	}
+}

--- a/src/main/java/tictac7x/charges/items/helms/H_TanzaniteHelm.java
+++ b/src/main/java/tictac7x/charges/items/helms/H_TanzaniteHelm.java
@@ -5,15 +5,11 @@ import tictac7x.charges.item.triggers.TriggerItem;
 import tictac7x.charges.store.Provider;
 import tictac7x.charges.store.ids.ItemId;
 
-public class H_TanzaniteHelm extends H_SerpentineHelm
-{
-	public H_TanzaniteHelm(final Provider provider)
-	{
-		super(TicTac7xChargesImprovedConfig.tanzanite_helm, ItemId.SERPENTINE_TANZANITE_HELM, provider);
-
-		this.items = new TriggerItem[]{
-			new TriggerItem(ItemId.SERPENTINE_TANZANITE_HELM_UNCHARGED).fixedCharges(0),
-			new TriggerItem(ItemId.SERPENTINE_TANZANITE_HELM)
-		};
-	}
+public class H_TanzaniteHelm extends H_SerpentineHelm {
+    public H_TanzaniteHelm(final Provider provider) {
+        super(TicTac7xChargesImprovedConfig.tanzanite_helm, ItemId.SERPENTINE_TANZANITE_HELM, new TriggerItem[]{
+            new TriggerItem(ItemId.SERPENTINE_TANZANITE_HELM_UNCHARGED).fixedCharges(0),
+            new TriggerItem(ItemId.SERPENTINE_TANZANITE_HELM)
+        }, provider);
+    }
 }

--- a/src/main/java/tictac7x/charges/store/ids/ItemId.java
+++ b/src/main/java/tictac7x/charges/store/ids/ItemId.java
@@ -1691,7 +1691,15 @@ public final class ItemId {
     public static final int AVAS_ASSEMBLER_MAX_SKILLCAPE_MASORI = ItemID.SKILLCAPE_MAX_ASSEMBLER_MASORI;
     public static final int AVAS_ASSEMBLER_MAX_SKILLCAPE_MASORI_TROUVER = ItemID.SKILLCAPE_MAX_ASSEMBLER_MASORI_TROUVER;
 
-    // Bow string spool
+    // Serpentine helm
+	public static final int SERPENTINE_HELM_UNCHARGED = ItemID.SERPENTINE_HELM;
+	public static final int SERPENTINE_HELM = ItemID.SERPENTINE_HELM_CHARGED;
+	public static final int SERPENTINE_MAGMA_HELM_UNCHARGED = ItemID.SERPENTINE_HELM_RED;
+	public static final int SERPENTINE_MAGMA_HELM = ItemID.SERPENTINE_HELM_CHARGED_RED;
+	public static final int SERPENTINE_TANZANITE_HELM_UNCHARGED = ItemID.SERPENTINE_HELM_CYAN;
+	public static final int SERPENTINE_TANZANITE_HELM = ItemID.SERPENTINE_HELM_CHARGED_CYAN;
+
+	// Bow string spool
     public static final int BOW_STRING_SPOOL = ItemID.BOWSTRING_SPOOL;
 
     // Craw's bow


### PR DESCRIPTION
- Added support for tracking the charges on the Serpentine Helm

I also added support for the different variants, but I was unable to test it. Though if the Echo Venator Bow PR is anything to go by, it should work. Note, the way the Serp helm works is that the moment you get into combat, you lose 10 scales, followed by another 10 for every 90 ticks which you remain in combat. I wasn't comfortable with hacking in a way to handle this, so I didn't implement it. Additionally, I'm not sure how Jagex handles _grace periods_ because lets say you just finished fighting one NPC. You won't lose 10 immediately when you get into combat with another NPC. If you have any ideas or if you'd like to work on it yourself, that would be wonderful.

Closes #429

---


https://github.com/user-attachments/assets/067185b8-f38c-4606-b684-8d4d536d0820

The preview doesn't show the automatic degrading while in combat because I would've exceeded upload file size limit.

