### PR TITLE
Add Echo ahrim's set

### DIFF
--- a/src/main/java/tictac7x/charges/items/barrows/AhrimsHood.java
+++ b/src/main/java/tictac7x/charges/items/barrows/AhrimsHood.java
@@ -14,6 +14,14 @@ public class AhrimsHood extends _BarrowsItem {
             new TriggerItem(ItemID.BARROWS_AHRIM_HEAD_50),
             new TriggerItem(ItemID.BARROWS_AHRIM_HEAD_25),
             new TriggerItem(ItemID.BARROWS_AHRIM_HEAD_BROKEN).fixedCharges(0),
+
+            // Echo ornament kit variants (Leagues V: Raging Echoes).
+            new TriggerItem(ItemID.BARROWS_AHRIM_HEAD_ORNAMENT).fixedCharges(1000),
+            new TriggerItem(ItemID.BARROWS_AHRIM_HEAD_ORNAMENT_100),
+            new TriggerItem(ItemID.BARROWS_AHRIM_HEAD_ORNAMENT_75),
+            new TriggerItem(ItemID.BARROWS_AHRIM_HEAD_ORNAMENT_50),
+            new TriggerItem(ItemID.BARROWS_AHRIM_HEAD_ORNAMENT_25),
+            new TriggerItem(ItemID.BARROWS_AHRIM_HEAD_ORNAMENT_BROKEN).fixedCharges(0),
         };
     }
 }

--- a/src/main/java/tictac7x/charges/items/barrows/AhrimsRobeskirt.java
+++ b/src/main/java/tictac7x/charges/items/barrows/AhrimsRobeskirt.java
@@ -14,6 +14,14 @@ public class AhrimsRobeskirt extends _BarrowsItem {
             new TriggerItem(ItemID.BARROWS_AHRIM_LEGS_50),
             new TriggerItem(ItemID.BARROWS_AHRIM_LEGS_25),
             new TriggerItem(ItemID.BARROWS_AHRIM_LEGS_BROKEN).fixedCharges(0),
+
+            // Echo ornament kit variants (Leagues V: Raging Echoes).
+            new TriggerItem(ItemID.BARROWS_AHRIM_LEGS_ORNAMENT).fixedCharges(1000),
+            new TriggerItem(ItemID.BARROWS_AHRIM_LEGS_ORNAMENT_100),
+            new TriggerItem(ItemID.BARROWS_AHRIM_LEGS_ORNAMENT_75),
+            new TriggerItem(ItemID.BARROWS_AHRIM_LEGS_ORNAMENT_50),
+            new TriggerItem(ItemID.BARROWS_AHRIM_LEGS_ORNAMENT_25),
+            new TriggerItem(ItemID.BARROWS_AHRIM_LEGS_ORNAMENT_BROKEN).fixedCharges(0),
         };
     }
 }

--- a/src/main/java/tictac7x/charges/items/barrows/AhrimsRobetop.java
+++ b/src/main/java/tictac7x/charges/items/barrows/AhrimsRobetop.java
@@ -14,6 +14,14 @@ public class AhrimsRobetop extends _BarrowsItem {
             new TriggerItem(ItemID.BARROWS_AHRIM_BODY_50),
             new TriggerItem(ItemID.BARROWS_AHRIM_BODY_25),
             new TriggerItem(ItemID.BARROWS_AHRIM_BODY_BROKEN).fixedCharges(0),
+
+            // Echo ornament kit variants (Leagues V: Raging Echoes).
+            new TriggerItem(ItemID.BARROWS_AHRIM_BODY_ORNAMENT).fixedCharges(1000),
+            new TriggerItem(ItemID.BARROWS_AHRIM_BODY_ORNAMENT_100),
+            new TriggerItem(ItemID.BARROWS_AHRIM_BODY_ORNAMENT_75),
+            new TriggerItem(ItemID.BARROWS_AHRIM_BODY_ORNAMENT_50),
+            new TriggerItem(ItemID.BARROWS_AHRIM_BODY_ORNAMENT_25),
+            new TriggerItem(ItemID.BARROWS_AHRIM_BODY_ORNAMENT_BROKEN).fixedCharges(0),
         };
     }
 }

--- a/src/main/java/tictac7x/charges/items/barrows/AhrimsStaff.java
+++ b/src/main/java/tictac7x/charges/items/barrows/AhrimsStaff.java
@@ -14,6 +14,14 @@ public class AhrimsStaff extends _BarrowsItem {
             new TriggerItem(ItemID.BARROWS_AHRIM_WEAPON_50),
             new TriggerItem(ItemID.BARROWS_AHRIM_WEAPON_25),
             new TriggerItem(ItemID.BARROWS_AHRIM_WEAPON_BROKEN).fixedCharges(0),
+
+            // Echo ornament kit variants (Leagues V: Raging Echoes).
+            new TriggerItem(ItemID.BARROWS_AHRIM_WEAPON_ORNAMENT).fixedCharges(1000),
+            new TriggerItem(ItemID.BARROWS_AHRIM_WEAPON_ORNAMENT_100),
+            new TriggerItem(ItemID.BARROWS_AHRIM_WEAPON_ORNAMENT_75),
+            new TriggerItem(ItemID.BARROWS_AHRIM_WEAPON_ORNAMENT_50),
+            new TriggerItem(ItemID.BARROWS_AHRIM_WEAPON_ORNAMENT_25),
+            new TriggerItem(ItemID.BARROWS_AHRIM_WEAPON_ORNAMENT_BROKEN).fixedCharges(0),
         };
     }
 }

--- a/src/main/java/tictac7x/charges/items/barrows/_BarrowsItem.java
+++ b/src/main/java/tictac7x/charges/items/barrows/_BarrowsItem.java
@@ -27,7 +27,7 @@ public class _BarrowsItem extends ChargedItem {
                 int chargesUsedInCurrentTier = (100 - percentage) * 250 / 100;
 
                 for (CustomMenuOptionClicked menuOptionClicked : provider.store.menuOptionsClicked) {
-                    if (menuOptionClicked.target.contains(provider.itemManager.getItemComposition(itemId).getName())) {
+                    if (menuOptionClicked.target.contains(provider.itemManager.getItemComposition(this.itemId).getName())) {
                         int currentTierMaxCharges = Integer.parseInt(menuOptionClicked.target.replaceAll("\\D", "")) * 10;
                         setCharges(currentTierMaxCharges - chargesUsedInCurrentTier);
                         return;


### PR DESCRIPTION
Hi @TicTac7x,

I've added support for the Echo ahrim's set to the plugin. I did also have to make a minor change to handling of barrows items to use the equipped item ID instead when handling `right click` -> `check` as it'd default to the unornamented ID otherwise.

This should close #445

Cheers for the great plugin :)