### PR TITLE
Add a Remove Mine when Full option and support for hopper count in case of multiple loads in flight

### DIFF
--- a/src/main/java/tictac7x/motherlode/Hopper.java
+++ b/src/main/java/tictac7x/motherlode/Hopper.java
@@ -10,6 +10,7 @@ public class Hopper {
     private final Client client;
     private final Inventory inventory;
     private int paydirt = 0;
+    private int lastSackPaydirt = -1;
 
     public Hopper(final Client client, final Inventory inventory) {
         this.client = client;
@@ -22,13 +23,17 @@ public class Hopper {
 
     public void onAnimationChanged(final AnimationChanged event) {
         if (event.getActor() == client.getLocalPlayer() && event.getActor().getAnimation() == AnimationId.DEPOSIT_PAYDIRT) {
-            paydirt = inventory.getPaydirt();
+            paydirt += inventory.getPaydirt();
         }
     }
 
     public void onVarbitChanged(final VarbitChanged event) {
-        if (event.getVarbitId() == VarbitId.MOTHERLODE_SACK_PAYDIRT) {
-            paydirt = 0;
+        if (event.getVarbitId() != VarbitId.MOTHERLODE_SACK_PAYDIRT) return;
+
+        final int sackPaydirt = event.getValue();
+        if (lastSackPaydirt >= 0 && sackPaydirt > lastSackPaydirt) {
+            paydirt = Math.max(0, paydirt - (sackPaydirt - lastSackPaydirt));
         }
+        lastSackPaydirt = sackPaydirt;
     }
 }

--- a/src/main/java/tictac7x/motherlode/TicTac7xMotherlodeConfig.java
+++ b/src/main/java/tictac7x/motherlode/TicTac7xMotherlodeConfig.java
@@ -32,6 +32,14 @@ public interface TicTac7xMotherlodeConfig extends Config {
 			section = general
 		) default boolean notifyToStopMining() { return true; }
 
+		@ConfigItem(
+			keyName = "remove_mine_when_full",
+			name = "Remove Mine when Full",
+			description = "Removes mine option from ore veins when sack would become full with already owned paydirt.",
+			position = 3,
+			section = general
+		) default boolean removeMineWhenFull() { return false; }
+
 	@ConfigSection(
 		name = "Ore veins and rockfalls",
 		description = "Highlight ore veins and rockfalls based on their states.",

--- a/src/main/java/tictac7x/motherlode/TicTac7xMotherlodePlugin.java
+++ b/src/main/java/tictac7x/motherlode/TicTac7xMotherlodePlugin.java
@@ -13,6 +13,7 @@ import net.runelite.api.events.GameObjectSpawned;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ItemContainerChanged;
+import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.events.WallObjectDespawned;
 import net.runelite.api.events.WallObjectSpawned;
@@ -145,6 +146,12 @@ public class TicTac7xMotherlodePlugin extends Plugin {
 	public void onAnimationChanged(final AnimationChanged event) {
 		if (!character.isInMotherlode()) return;
 		hopper.onAnimationChanged(event);
+	}
+
+	@Subscribe
+	public void onMenuEntryAdded(final MenuEntryAdded event) {
+		if (!character.isInMotherlode()) return;
+		oreVeins.onMenuEntryAdded(event);
 	}
 
 	@Subscribe

--- a/src/main/java/tictac7x/motherlode/oreveins/OreVein.java
+++ b/src/main/java/tictac7x/motherlode/oreveins/OreVein.java
@@ -168,8 +168,12 @@ public class OreVein {
     }
 
     public static boolean isOreVein(final WallObject wallObject) {
+        return isOreVein(wallObject.getId());
+    }
+
+    public static boolean isOreVein(final int wallObjectId) {
         for (final int oreVeinId : ORE_VEINS_IDS) {
-            if (wallObject.getId() == oreVeinId) return true;
+            if (wallObjectId == oreVeinId) return true;
         }
 
         return false;

--- a/src/main/java/tictac7x/motherlode/oreveins/OreVeins.java
+++ b/src/main/java/tictac7x/motherlode/oreveins/OreVeins.java
@@ -2,10 +2,13 @@ package tictac7x.motherlode.oreveins;
 
 import net.runelite.api.Actor;
 import net.runelite.api.GameState;
+import net.runelite.api.MenuAction;
+import net.runelite.api.MenuEntry;
 import net.runelite.api.Player;
 import net.runelite.api.WallObject;
 import net.runelite.api.events.AnimationChanged;
 import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.api.events.WallObjectDespawned;
 import net.runelite.api.events.WallObjectSpawned;
 import net.runelite.client.ui.overlay.Overlay;
@@ -73,6 +76,24 @@ public class OreVeins extends Overlay {
         for (final OreVein oreVein : oreVeins.values()) {
             oreVein.onGameTick();
         }
+    }
+
+    public void onMenuEntryAdded(final MenuEntryAdded event) {
+        if (!config.removeMineWhenFull() || !isOreVeinMineEntry(event.getMenuEntry()) || !motherlode.shouldStopMining()) return;
+
+        final List<MenuEntry> menuEntries = new ArrayList<>();
+
+        for (final MenuEntry menuEntry : provider.client.getMenu().getMenuEntries()) {
+            if (!isOreVeinMineEntry(menuEntry)) {
+                menuEntries.add(menuEntry);
+            }
+        }
+
+        provider.client.getMenu().setMenuEntries(menuEntries.toArray(new MenuEntry[0]));
+    }
+
+    private boolean isOreVeinMineEntry(final MenuEntry menuEntry) {
+        return menuEntry.getType() == MenuAction.GAME_OBJECT_FIRST_OPTION && OreVein.isOreVein(menuEntry.getIdentifier());
     }
 
     private void updateOreVein(final WallObject wallObject, final boolean isDepleted) {


### PR DESCRIPTION
The plugin already knows when further mining is wasted and notifies once. This adds an optional step on top of that: while the same condition holds, the `Mine` option is removed from ore veins, so a stray click cannot start a swing whose pay-dirt would not fit. Off by default, in the General section. It reuses `shouldStopMining()` and the existing ore vein id table, gates on `isInMotherlode()` like the other handlers, and filters menu entries the same way `plugin-charges` does.

It also extends the hopper count to cover more than one load being in the machine. The count is exact for a single load; if a second is deposited before the first lands, it now adds to the count rather than replacing it, and a sack increase subtracts what landed rather than clearing the count, so the remainder stays tracked until it arrives. Subtracting only on an increase also keeps a load in flight counted while you collect from the sack.
